### PR TITLE
ChatKitから自作AIチャットへ移行

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -8,7 +8,8 @@
     "test": "tsc --noEmit"
   },
   "devDependencies": {
-    "@assistant-ui/react": "^0.14.26",
+    "@assistant-ui/react": "^0.14.27",
+    "@assistant-ui/react-ai-sdk": "^1.3.41",
     "@babel/core": "^7.29.6",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -8,6 +8,7 @@
     "test": "tsc --noEmit"
   },
   "devDependencies": {
+    "@assistant-ui/react": "^0.14.26",
     "@babel/core": "^7.29.6",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
@@ -18,7 +19,6 @@
     "@mui/lab": "^7.0.1-beta.18",
     "@mui/material": "^7.3.4",
     "@mui/styles": "^6.4.8",
-    "@openai/chatkit-react": "^1.5.0",
     "@types/grecaptcha": "^3.0.9",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -23,6 +23,7 @@
     "@types/grecaptcha": "^3.0.9",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "ai": "^7.0.31",
     "assert": "^2.1.0",
     "babel-loader": "^10.0.0",
     "babel-plugin-static-fs": "^3.0.0",
@@ -39,7 +40,7 @@
     "serve": "^14.2.6",
     "webpack": "^5.104.1",
     "webpack-cli": "^5.1.4",
-    "zod": "^4.1.12"
+    "zod": "^4.4.3"
   },
   "resolutions": {
     "re2": "^1.22.1"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf docs && webpack --config webpack.prod.js",
+    "build": "rm -rf docs && tailwindcss -i src/index.css -o docs/index.css && webpack --config webpack.prod.js",
     "start": "serve -l 8080 docs",
     "test": "tsc --noEmit"
   },
@@ -21,6 +21,8 @@
     "@mui/lab": "^7.0.1-beta.18",
     "@mui/material": "^7.3.4",
     "@mui/styles": "^6.4.8",
+    "@tailwindcss/cli": "^4.3.3",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/grecaptcha": "^3.0.9",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
@@ -40,6 +42,7 @@
     "react-is": "^19.2.0",
     "remark-gfm": "^4.0.1",
     "serve": "^14.2.6",
+    "tailwindcss": "^4.3.3",
     "webpack": "^5.104.1",
     "webpack-cli": "^5.1.4",
     "zod": "^4.4.3"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@assistant-ui/react": "^0.14.27",
     "@assistant-ui/react-ai-sdk": "^1.3.41",
+    "@assistant-ui/react-markdown": "^0.14.6",
     "@babel/core": "^7.29.6",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
@@ -37,6 +38,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-is": "^19.2.0",
+    "remark-gfm": "^4.0.1",
     "serve": "^14.2.6",
     "webpack": "^5.104.1",
     "webpack-cli": "^5.1.4",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -16,6 +16,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@heroicons/react": "^2.2.0",
     "@microsoft/clarity": "^1.0.0",
     "@mui/icons-material": "^7.3.4",
     "@mui/lab": "^7.0.1-beta.18",

--- a/packages/website/resources/index.html
+++ b/packages/website/resources/index.html
@@ -9,11 +9,11 @@
 
         connect-src
           'self'
+          https://ai-chat-788918986145.asia-northeast1.run.app
           https://c.bing.com
           https://*.clarity.ms
           https://www.google.com/recaptcha/
           https://cdn.platform.openai.com
-          https://chatkit-session-788918986145.us-central1.run.app
         ;
 
         frame-src
@@ -68,10 +68,6 @@
     <div class="app"></div>
 
     <script src="https://www.google.com/recaptcha/enterprise.js?render=6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF"></script>
-    <script
-      src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js"
-      async
-    ></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/packages/website/resources/index.html
+++ b/packages/website/resources/index.html
@@ -40,15 +40,7 @@
     />
 
     <title>校正さん</title>
-
     <meta name="description" content="スマホで使える文章校正メモ" />
-    <link rel="manifest" href="manifest.json" />
-    <meta name="robots" content="noindex" />
-    <meta
-      name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width"
-    />
-
     <meta property="og:description" content="スマホで使える文章校正メモ" />
     <meta
       property="og:image"
@@ -57,9 +49,17 @@
     <meta property="og:title" content="校正さん" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://kohsei-san.hata6502.com/" />
-
     <meta name="twitter:card" content="summary" />
 
+    <meta name="robots" content="noindex" />
+
+    <meta
+      name="viewport"
+      content="minimum-scale=1, initial-scale=1, width=device-width"
+    />
+
+    <link rel="manifest" href="manifest.json" />
+    <link rel="stylesheet" href="index.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="apple-touch-icon" href="favicon.png" />
   </head>

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -59,8 +59,8 @@ export const Chat: FunctionComponent<{
       },
     }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-    onError: (exception) => {
-      console.error("Chat request failed", exception);
+    onError: (error) => {
+      console.error("Chat request failed", error);
     },
   });
 

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -1,12 +1,13 @@
 import {
   AssistantRuntimeProvider,
-  AuiIf,
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
-  useLocalRuntime,
 } from "@assistant-ui/react";
-import type { ChatModelAdapter } from "@assistant-ui/react";
+import {
+  AssistantChatTransport,
+  useChatRuntime,
+} from "@assistant-ui/react-ai-sdk";
 import React from "react";
 import type { Dispatch, FunctionComponent } from "react";
 import { z } from "zod";
@@ -15,40 +16,28 @@ import type { ProofreadingMessage } from "../lintWorker";
 import { getMemoTitle } from "../useMemo";
 import type { Memo, MemosAction } from "../useMemo";
 
-const adapter: ChatModelAdapter = {
-  async run({ messages, abortSignal }) {
-    await new Promise<void>((resolve) => grecaptcha.enterprise.ready(resolve));
-    const recaptchaToken = await grecaptcha.enterprise.execute(
-      "6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF",
-      { action: "GET_CLIENT_SECRET" },
-    );
-
-    const response = await fetch(
-      "https://ai-chat-788918986145.asia-northeast1.run.app/",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ recaptchaToken, messages }),
-        signal: abortSignal,
-      },
-    );
-    if (!response.ok) {
-      throw new Error(); // TODO: error message
-    }
-    const data = z.object({ text: z.string() }).parse(await response.json());
-
-    return {
-      content: [{ type: "text", text: data.text }],
-    };
-  },
-};
-
 export const Chat: FunctionComponent<{
   memo: Memo;
   memos: Memo[];
   dispatchMemos: Dispatch<MemosAction>;
 }> = ({ memo, memos, dispatchMemos }) => {
-  const runtime = useLocalRuntime(adapter);
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({
+      api: "https://ai-chat-788918986145.asia-northeast1.run.app/",
+      body: async () => {
+        // HTTPリクエストのたびに新しいreCAPTCHA tokenを取得する必要あり
+        await new Promise<void>((resolve) =>
+          grecaptcha.enterprise.ready(resolve),
+        );
+        const recaptchaToken = await grecaptcha.enterprise.execute(
+          "6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF",
+          { action: "GET_CLIENT_SECRET" },
+        );
+
+        return { recaptchaToken };
+      },
+    }),
+  });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -20,6 +20,42 @@ import type { ProofreadingMessage } from "../lintWorker";
 import { getMemoTitle } from "../useMemo";
 import type { Memo, MemosAction } from "../useMemo";
 
+const getMemoParameters = z.object({});
+type GetMemoParameters = z.infer<typeof getMemoParameters>;
+type GetMemoResult = Pick<Memo, "result" | "text">;
+
+const listOtherMemosParameters = z.object({});
+type ListOtherMemosParameters = z.infer<typeof listOtherMemosParameters>;
+interface ListOtherMemosResult {
+  memos: (Pick<Memo, "id" | "updatedAt"> & { title: string })[];
+}
+
+const getOtherMemosParameters = z.object({ ids: z.array(z.string()) });
+type GetOtherMemosParameters = z.infer<typeof getOtherMemosParameters>;
+interface GetOtherMemosResult {
+  memos: Pick<Memo, "id" | "text">[];
+}
+
+const setAILintMessagesParameters = z.object({
+  messages: z.array(
+    z.object({
+      line: z.number().min(1).describe("1-based line number"),
+      column: z.number().min(1).describe("1-based column number"),
+      text: z
+        .string()
+        .describe("Text at the line/column position, for validation"),
+      message: z.string(),
+      fix: z
+        .object({
+          text: z.string().describe("Replacement text for text"),
+        })
+        .nullable(),
+    }),
+  ),
+});
+type SetAILintMessagesParameters = z.infer<typeof setAILintMessagesParameters>;
+interface SetAILintMessagesResult {}
+
 export const Chat: FunctionComponent<{
   memo: Memo;
   memos: Memo[];
@@ -33,12 +69,154 @@ export const Chat: FunctionComponent<{
         get_memo: {
           type: "frontend",
           description: "文章を取得する",
-          parameters: z.object({}),
-          execute: () => ({ result: memo.result, text: memo.text }),
-          renderText: { complete: "文章を読みました" },
+          parameters: getMemoParameters,
+          execute: ({}: GetMemoParameters): GetMemoResult => ({
+            result: memo.result,
+            text: memo.text,
+          }),
+          renderText: { complete: "文章を読みました。" },
+        },
+        list_other_memos: {
+          type: "frontend",
+          description: "他のメモの一覧を取得する",
+          parameters: listOtherMemosParameters,
+          execute: ({}: ListOtherMemosParameters): ListOtherMemosResult => ({
+            memos: memos
+              .filter(({ id }) => id !== memo.id)
+              .map((memo) => ({
+                id: memo.id,
+                title: getMemoTitle(memo),
+                updatedAt: memo.updatedAt,
+              })),
+          }),
+          renderText: { complete: "メモの一覧を取得しました。" },
+        },
+        get_other_memos: {
+          type: "frontend",
+          description: "指定した他のメモの本文を取得する",
+          parameters: getOtherMemosParameters,
+          execute: ({ ids }: GetOtherMemosParameters): GetOtherMemosResult => ({
+            memos: ids.map((id) => {
+              const otherMemo = memos.find(
+                (otherMemo) => otherMemo.id === id && otherMemo.id !== memo.id,
+              );
+              if (!otherMemo) {
+                throw new Error(`Unknown other memo id: ${id}`);
+              }
+              return { id: otherMemo.id, text: otherMemo.text };
+            }),
+          }),
+          renderText: {
+            complete: ({ result }: { result: GetOtherMemosResult }) =>
+              `メモ${result.memos.map((memo) => `「${getMemoTitle(memo)}」`).join("")}を読みました。`,
+          },
+        },
+        set_ai_lint_messages: {
+          type: "frontend",
+          description: "AIによる見直し箇所をセットする",
+          parameters: setAILintMessagesParameters,
+          execute: ({
+            messages,
+          }: SetAILintMessagesParameters): SetAILintMessagesResult => {
+            const errors: string[] = [];
+
+            const aiMessages: ProofreadingMessage[] = messages.flatMap(
+              (message) => {
+                const lines = memo.text.split("\n");
+                const lineText = lines.at(message.line - 1);
+                if (lineText === undefined) {
+                  errors.push(
+                    `line ${message.line}: line out of range (1-${lines.length})`,
+                  );
+                  return [];
+                }
+
+                const graphemes = [
+                  ...new Intl.Segmenter().segment(lineText),
+                ].map(({ segment }) => segment);
+                if (message.column > graphemes.length + 1) {
+                  errors.push(
+                    `line ${message.line}, column ${message.column}: column out of range (1-${graphemes.length + 1})`,
+                  );
+                  return [];
+                }
+
+                const index =
+                  lines
+                    .slice(0, message.line - 1)
+                    .reduce((sum, line) => sum + line.length + 1, 0) +
+                  graphemes.slice(0, message.column - 1).join("").length;
+
+                const actual = memo.text.slice(
+                  index,
+                  index + message.text.length,
+                );
+
+                if (actual !== message.text) {
+                  errors.push(
+                    `line ${message.line}, column ${message.column}: expected "${message.text}" but found "${actual}"`,
+                  );
+                  return [];
+                }
+
+                return [
+                  {
+                    ruleId: "ai",
+                    message: message.message,
+                    index,
+                    severity: 0,
+                    ...(message.fix && {
+                      fix: {
+                        range: [index, index + message.text.length],
+                        text: message.fix.text,
+                      },
+                    }),
+                  },
+                ];
+              },
+            );
+
+            if (errors.length > 0) {
+              throw new Error(
+                `
+                  Validation failed.
+                  Please retry set_ai_lint_messages with correct 1-based line and column values.
+
+                  ${errors.join("\n")}
+
+                  Full text for reference:
+                  ${memo.text}
+                `,
+              );
+            }
+
+            dispatchMemos((prevMemos) =>
+              prevMemos.map((prevMemo) => {
+                if (prevMemo.id !== memo.id) {
+                  return prevMemo;
+                }
+
+                return {
+                  ...prevMemo,
+                  result: {
+                    ...prevMemo.result,
+                    messages: [
+                      ...(prevMemo.result?.messages.filter(
+                        (message) => message.ruleId !== "ai",
+                      ) ?? []),
+                      ...aiMessages,
+                    ],
+                  },
+                };
+              }),
+            );
+
+            return {};
+          },
+          renderText: { complete: "見直し箇所を表示しました。" },
         },
       }),
-    [memo.result, memo.text],
+    [memo.result, memo.text, memos],
   );
   const aui = useAui({ tools: Tools({ toolkit }) });
 
@@ -88,217 +266,8 @@ export const Chat: FunctionComponent<{
   );
 };
 
-/*const toolCallSchema = z.union([
-  z.object({
-  }),
-  z.object({
-    name: z.literal("list_other_memos"),
-    params: z.object({}),
-  }),
-  z.object({
-    name: z.literal("get_other_memos"),
-    params: z.object({
-      ids: z.array(z.string()),
-    }),
-  }),
-  z.object({
-    name: z.literal("set_ai_lint_messages"),
-    params: z.object({
-      messages: z.array(
-        z.object({
-          line: z.number().min(1).describe("1-based line number"),
-          column: z.number().min(1).describe("1-based column number"),
-          text: z
-            .string()
-            .describe("Text at the line/column position, for validation"),
-          message: z.string(),
-          fix: z
-            .object({
-              text: z.string().describe("Replacement text for text"),
-            })
-            .nullable(),
-        }),
-      ),
-    }),
-  }),
-]);
-
-export const Chat: FunctionComponent<{
-  memo: Memo;
-  memos: Memo[];
-  dispatchMemos: Dispatch<MemosAction>;
-}> = ({ memo, memos, dispatchMemos }) => {
-  const handleClientTool: NonNullable<ChatKitOptions["onClientTool"]> = (
-    toolCall,
-  ) => {
-    try {
-      console.log("onClientTool", toolCall);
-
-      const { name, params } = toolCallSchema.parse(toolCall);
-      switch (name) {
-        case "list_other_memos": {
-          return {
-            memos: memos
-              .filter(({ id }) => id !== memo.id)
-              .map((memo) => ({
-                id: memo.id,
-                title: getMemoTitle(memo),
-                updatedAt: memo.updatedAt,
-              })),
-          };
-        }
-
-        case "get_other_memos": {
-          return {
-            memos: params.ids.map((id) => {
-              const otherMemo = memos.find(
-                (otherMemo) => otherMemo.id === id && otherMemo.id !== memo.id,
-              );
-              if (!otherMemo) {
-                throw new Error(`Unknown other memo id: ${id}`);
-              }
-
-              return {
-                id: otherMemo.id,
-                text: otherMemo.text,
-              };
-            }),
-          };
-        }
-
-        case "set_ai_lint_messages": {
-          const errors: string[] = [];
-
-          const aiMessages: ProofreadingMessage[] = params.messages.flatMap(
-            (message) => {
-              const lines = memo.text.split("\n");
-              const lineText = lines.at(message.line - 1);
-              if (lineText === undefined) {
-                errors.push(
-                  `line ${message.line}: line out of range (1-${lines.length})`,
-                );
-                return [];
-              }
-
-              const graphemes = [...new Intl.Segmenter().segment(lineText)].map(
-                ({ segment }) => segment,
-              );
-              if (message.column > graphemes.length + 1) {
-                errors.push(
-                  `line ${message.line}, column ${message.column}: column out of range (1-${graphemes.length + 1})`,
-                );
-                return [];
-              }
-
-              const index =
-                lines
-                  .slice(0, message.line - 1)
-                  .reduce((sum, line) => sum + line.length + 1, 0) +
-                graphemes.slice(0, message.column - 1).join("").length;
-
-              const actual = memo.text.slice(
-                index,
-                index + message.text.length,
-              );
-
-              if (actual !== message.text) {
-                errors.push(
-                  `line ${message.line}, column ${message.column}: expected "${message.text}" but found "${actual}"`,
-                );
-                return [];
-              }
-
-              return [
-                {
-                  ruleId: "ai",
-                  message: message.message,
-                  index,
-                  severity: 0,
-                  ...(message.fix && {
-                    fix: {
-                      range: [index, index + message.text.length],
-                      text: message.fix.text,
-                    },
-                  }),
-                },
-              ];
-            },
-          );
-
-          if (errors.length > 0) {
-            throw new Error(
-              `
-                Validation failed.
-                Please retry set_ai_lint_messages with correct 1-based line and column values.
-
-                ${errors.join("\n")}
-
-                Full text for reference:
-                ${memo.text}
-              `,
-            );
-          }
-
-          dispatchMemos((prevMemos) =>
-            prevMemos.map((prevMemo) => {
-              if (prevMemo.id !== memo.id) {
-                return prevMemo;
-              }
-
-              return {
-                ...prevMemo,
-                result: {
-                  ...prevMemo.result,
-                  messages: [
-                    ...(prevMemo.result?.messages.filter(
-                      (message) => message.ruleId !== "ai",
-                    ) ?? []),
-                    ...aiMessages,
-                  ],
-                },
-              };
-            }),
-          );
-
-          return {};
-        }
-
-        default: {
-          throw new Error(`Unknown tool: ${name satisfies never}`);
-        }
-      }
-    } catch (exception) {
-      console.error(exception);
-
-      return { exception: String(exception) };
-    }
-  };
-
+/*
   const { control } = useChatKit({
-    api: {
-      getClientSecret: async () => {
-        const response = await fetch(
-          "https://chatkit-session-788918986145.us-central1.run.app/",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              userID: memo.id,
-            }),
-          },
-        );
-        if (!response.ok) {
-          throw new Error(
-            `Failed to create session: ${response.status} ${response.statusText}`,
-          );
-        }
-        const { clientSecret } = await response.json();
-
-        return clientSecret;
-      },
-    },
     composer: {
       attachments: { enabled: true },
       placeholder: "校正さんに相談する",

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -3,12 +3,16 @@ import {
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
+  Tools,
+  defineToolkit,
+  useAui,
 } from "@assistant-ui/react";
 import {
   AssistantChatTransport,
   useChatRuntime,
 } from "@assistant-ui/react-ai-sdk";
-import React from "react";
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import React, { useMemo } from "react";
 import type { Dispatch, FunctionComponent } from "react";
 import { z } from "zod";
 
@@ -21,6 +25,23 @@ export const Chat: FunctionComponent<{
   memos: Memo[];
   dispatchMemos: Dispatch<MemosAction>;
 }> = ({ memo, memos, dispatchMemos }) => {
+  // useMemoを入れて安定化する
+  // https://www.assistant-ui.com/docs/api-reference/tools
+  const toolkit = useMemo(
+    () =>
+      defineToolkit({
+        get_memo: {
+          type: "frontend",
+          description: "文章を取得する",
+          parameters: z.object({}),
+          execute: () => ({ result: memo.result, text: memo.text }),
+          renderText: { complete: "文章を読みました" },
+        },
+      }),
+    [memo.result, memo.text],
+  );
+  const aui = useAui({ tools: Tools({ toolkit }) });
+
   const runtime = useChatRuntime({
     transport: new AssistantChatTransport({
       api: "https://ai-chat-788918986145.asia-northeast1.run.app/",
@@ -37,10 +58,14 @@ export const Chat: FunctionComponent<{
         return { recaptchaToken };
       },
     }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    onError: (exception) => {
+      console.error("Chat request failed", exception);
+    },
   });
 
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
       <ThreadPrimitive.Root>
         <ThreadPrimitive.Viewport>
           <ThreadPrimitive.Messages>
@@ -65,8 +90,6 @@ export const Chat: FunctionComponent<{
 
 /*const toolCallSchema = z.union([
   z.object({
-    name: z.literal("get_memo"),
-    params: z.object({}),
   }),
   z.object({
     name: z.literal("list_other_memos"),
@@ -99,10 +122,6 @@ export const Chat: FunctionComponent<{
     }),
   }),
 ]);
-// ブラウザの console から printToolSchema() で JSON Schema を出力できる
-// @ts-expect-error
-window.printToolSchema = () =>
-  console.log(JSON.stringify(z.toJSONSchema(toolCallSchema), null, 2));
 
 export const Chat: FunctionComponent<{
   memo: Memo;
@@ -117,10 +136,6 @@ export const Chat: FunctionComponent<{
 
       const { name, params } = toolCallSchema.parse(toolCall);
       switch (name) {
-        case "get_memo": {
-          return { result: memo.result, text: memo.text };
-        }
-
         case "list_other_memos": {
           return {
             memos: memos

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -1,14 +1,80 @@
+import {
+  AssistantRuntimeProvider,
+  AuiIf,
+  ComposerPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+  useLocalRuntime,
+} from "@assistant-ui/react";
+import type { ChatModelAdapter } from "@assistant-ui/react";
 import React from "react";
 import type { Dispatch, FunctionComponent } from "react";
-import { ChatKit, useChatKit } from "@openai/chatkit-react";
-import type { ChatKitOptions } from "@openai/chatkit-react";
 import { z } from "zod";
 
 import type { ProofreadingMessage } from "../lintWorker";
 import { getMemoTitle } from "../useMemo";
 import type { Memo, MemosAction } from "../useMemo";
 
-const toolCallSchema = z.union([
+const adapter: ChatModelAdapter = {
+  async run({ messages, abortSignal }) {
+    await new Promise<void>((resolve) => grecaptcha.enterprise.ready(resolve));
+    const recaptchaToken = await grecaptcha.enterprise.execute(
+      "6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF",
+      { action: "GET_CLIENT_SECRET" },
+    );
+
+    const response = await fetch(
+      "https://ai-chat-788918986145.asia-northeast1.run.app/",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recaptchaToken, messages }),
+        signal: abortSignal,
+      },
+    );
+    if (!response.ok) {
+      throw new Error(); // TODO: error message
+    }
+    const data = z.object({ text: z.string() }).parse(await response.json());
+
+    return {
+      content: [{ type: "text", text: data.text }],
+    };
+  },
+};
+
+export const Chat: FunctionComponent<{
+  memo: Memo;
+  memos: Memo[];
+  dispatchMemos: Dispatch<MemosAction>;
+}> = ({ memo, memos, dispatchMemos }) => {
+  const runtime = useLocalRuntime(adapter);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadPrimitive.Root>
+        <ThreadPrimitive.Viewport>
+          <ThreadPrimitive.Messages>
+            {() => (
+              <MessagePrimitive.Root>
+                <MessagePrimitive.Parts />
+              </MessagePrimitive.Root>
+            )}
+          </ThreadPrimitive.Messages>
+
+          <ThreadPrimitive.ViewportFooter className="sticky bottom-0 pt-2">
+            <ComposerPrimitive.Root>
+              <ComposerPrimitive.Input placeholder="Ask anything..." />
+              <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+            </ComposerPrimitive.Root>
+          </ThreadPrimitive.ViewportFooter>
+        </ThreadPrimitive.Viewport>
+      </ThreadPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+};
+
+/*const toolCallSchema = z.union([
   z.object({
     name: z.literal("get_memo"),
     params: z.object({}),
@@ -207,14 +273,6 @@ export const Chat: FunctionComponent<{
   const { control } = useChatKit({
     api: {
       getClientSecret: async () => {
-        await new Promise<void>((resolve) =>
-          grecaptcha.enterprise.ready(resolve),
-        );
-        const recaptchaToken = await grecaptcha.enterprise.execute(
-          "6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF",
-          { action: "GET_CLIENT_SECRET" },
-        );
-
         const response = await fetch(
           "https://chatkit-session-788918986145.us-central1.run.app/",
           {
@@ -223,7 +281,6 @@ export const Chat: FunctionComponent<{
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              recaptchaToken,
               userID: memo.id,
             }),
           },
@@ -274,4 +331,4 @@ export const Chat: FunctionComponent<{
   });
 
   return <ChatKit control={control} style={{ height: 500 }} />;
-};
+};*/

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionBarPrimitive,
   AssistantRuntimeProvider,
   AuiIf,
   ComposerPrimitive,
@@ -269,16 +270,37 @@ export const Chat: FunctionComponent<{
           </AuiIf>
 
           <ThreadPrimitive.Messages>
-            {() => (
+            {({ message }) => (
               <MessagePrimitive.Root>
-                <MessagePrimitive.Parts />
+                {message.composer.isEditing ? (
+                  <ComposerPrimitive.Root>
+                    <ComposerPrimitive.Input autoFocus />
+
+                    <ComposerPrimitive.Cancel>Cancel</ComposerPrimitive.Cancel>
+                    <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+                  </ComposerPrimitive.Root>
+                ) : (
+                  <>
+                    <MessagePrimitive.Parts />
+
+                    <ActionBarPrimitive.Root>
+                      {{
+                        system: false,
+                        user: true,
+                        assistant: false,
+                      }[message.role] && (
+                        <ActionBarPrimitive.Edit>Edit</ActionBarPrimitive.Edit>
+                      )}
+                    </ActionBarPrimitive.Root>
+                  </>
+                )}
               </MessagePrimitive.Root>
             )}
           </ThreadPrimitive.Messages>
 
-          <ThreadPrimitive.ViewportFooter className="sticky bottom-0 pt-2">
+          <ThreadPrimitive.ViewportFooter>
             <ComposerPrimitive.Root>
-              <ComposerPrimitive.Input placeholder="Ask anything..." />
+              <ComposerPrimitive.Input placeholder="校正さんに相談する" />
               <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
             </ComposerPrimitive.Root>
           </ThreadPrimitive.ViewportFooter>
@@ -289,17 +311,5 @@ export const Chat: FunctionComponent<{
 };
 
 /*
-  const { control } = useChatKit({
-    composer: {
-      attachments: { enabled: true },
-      placeholder: "校正さんに相談する",
-    },
-    threadItemActions: {
-      feedback: true,
-      retry: true,
-    },
-    onClientTool: handleClientTool,
-  });
-
   return <ChatKit control={control} style={{ height: 500 }} />;
 };*/

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -1,7 +1,10 @@
 import {
   AssistantRuntimeProvider,
+  AuiIf,
   ComposerPrimitive,
   MessagePrimitive,
+  Suggestions,
+  SuggestionPrimitive,
   ThreadPrimitive,
   Tools,
   defineToolkit,
@@ -218,7 +221,16 @@ export const Chat: FunctionComponent<{
       }),
     [memo.result, memo.text, memos],
   );
-  const aui = useAui({ tools: Tools({ toolkit }) });
+  const aui = useAui({
+    tools: Tools({ toolkit }),
+    suggestions: Suggestions([
+      "文章全体を校閲して",
+      "他のメモとのズレを探して",
+      "飾りっぽい表現や造語を見直して",
+      "機密情報を伏せ字に置換して",
+      "文章から読み取れる感情を教えて",
+    ]),
+  });
 
   const runtime = useChatRuntime({
     transport: new AssistantChatTransport({
@@ -246,6 +258,16 @@ export const Chat: FunctionComponent<{
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>
       <ThreadPrimitive.Root>
         <ThreadPrimitive.Viewport>
+          <AuiIf condition={(state) => state.thread.isEmpty}>
+            <ThreadPrimitive.Suggestions>
+              {() => (
+                <SuggestionPrimitive.Trigger send>
+                  <SuggestionPrimitive.Title />
+                </SuggestionPrimitive.Trigger>
+              )}
+            </ThreadPrimitive.Suggestions>
+          </AuiIf>
+
           <ThreadPrimitive.Messages>
             {() => (
               <MessagePrimitive.Root>
@@ -271,30 +293,6 @@ export const Chat: FunctionComponent<{
     composer: {
       attachments: { enabled: true },
       placeholder: "校正さんに相談する",
-    },
-    startScreen: {
-      prompts: [
-        {
-          label: "文章全体を校閲して",
-          prompt: "文章全体を校閲して",
-        },
-        {
-          label: "他のメモとのズレを探して",
-          prompt: "他のメモとのズレを探して",
-        },
-        {
-          label: "飾りっぽい表現や造語を見直して",
-          prompt: "飾りっぽい表現や造語を見直して",
-        },
-        {
-          label: "機密情報を伏せ字に置換して",
-          prompt: "機密情報を伏せ字に置換して",
-        },
-        {
-          label: "文章から読み取れる感情を教えて",
-          prompt: "文章から読み取れる感情を教えて",
-        },
-      ],
     },
     threadItemActions: {
       feedback: true,

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -1,7 +1,6 @@
 import {
   ActionBarPrimitive,
   AssistantRuntimeProvider,
-  AuiIf,
   ComposerPrimitive,
   MessagePrimitive,
   Suggestions,
@@ -10,11 +9,19 @@ import {
   Tools,
   defineToolkit,
   useAui,
+  InMemoryThreadListAdapter,
+  useRemoteThreadListRuntime,
+} from "@assistant-ui/react";
+import type {
+  MessageStorageEntry,
+  ThreadHistoryAdapter,
 } from "@assistant-ui/react";
 import {
   AssistantChatTransport,
   useChatRuntime,
 } from "@assistant-ui/react-ai-sdk";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import React, { useMemo } from "react";
 import type { Dispatch, FunctionComponent } from "react";
@@ -222,6 +229,7 @@ export const Chat: FunctionComponent<{
       }),
     [memo.result, memo.text, memos],
   );
+
   const aui = useAui({
     tools: Tools({ toolkit }),
     suggestions: Suggestions([
@@ -233,83 +241,181 @@ export const Chat: FunctionComponent<{
     ]),
   });
 
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({
-      api: "https://ai-chat-788918986145.asia-northeast1.run.app/",
-      body: async () => {
-        // HTTPリクエストのたびに新しいreCAPTCHA tokenを取得する必要あり
-        await new Promise<void>((resolve) =>
-          grecaptcha.enterprise.ready(resolve),
-        );
-        const recaptchaToken = await grecaptcha.enterprise.execute(
-          "6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF",
-          { action: "GET_CLIENT_SECRET" },
-        );
+  class SingleThreadListAdapter extends InMemoryThreadListAdapter {
+    async fetch(threadId: string) {
+      const threadMemo = memos.find((memo) => memo.id === threadId);
+      if (!threadMemo?.chatHistoryHeadID) {
+        throw new Error(`Chat history head not found for memo: ${threadId}`);
+      }
 
-        return { recaptchaToken };
-      },
-    }),
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-    onError: (error) => {
-      console.error("Chat request failed", error);
+      return { remoteId: threadMemo.id, status: "regular" as const };
+    }
+  }
+
+  const history: ThreadHistoryAdapter = {
+    load: async () => ({ headId: null, messages: [] }),
+    append: async () => {},
+    withFormat: (formatAdapter) => {
+      type ChatHistoryItem = MessageStorageEntry<
+        ReturnType<typeof formatAdapter.encode>
+      >;
+
+      const getChatHistory = (): ChatHistoryItem[] =>
+        JSON.parse(localStorage.getItem("chatHistory") ?? "[]");
+      const setChatHistory = (
+        action: (prevChatHistory: ChatHistoryItem[]) => ChatHistoryItem[],
+      ) => {
+        localStorage.setItem(
+          "chatHistory",
+          JSON.stringify(action(getChatHistory())),
+        );
+      };
+
+      return {
+        load: async () => {
+          setChatHistory((prevChatHistory) => {
+            const reachableMessageIDs = new Set<string>();
+            for (const memo of memos) {
+              let messageID = memo.chatHistoryHeadID;
+              while (messageID) {
+                reachableMessageIDs.add(messageID);
+
+                messageID =
+                  prevChatHistory.find(
+                    (chatHistoryItem) => chatHistoryItem.id === messageID,
+                  )?.parent_id ?? undefined;
+              }
+            }
+
+            return prevChatHistory.filter((chatHistoryItem) =>
+              reachableMessageIDs.has(chatHistoryItem.id),
+            );
+          });
+
+          return {
+            headId: memo.chatHistoryHeadID,
+            messages: getChatHistory().map(formatAdapter.decode),
+          };
+        },
+        append: async (item) => {
+          const id = formatAdapter.getId(item.message);
+
+          setChatHistory((prevChatHistory) => {
+            const chatHistory = [...prevChatHistory];
+            chatHistory.push({
+              id,
+              parent_id: item.parentId,
+              format: formatAdapter.format,
+              content: formatAdapter.encode(item),
+            });
+            return chatHistory;
+          });
+
+          dispatchMemos((prevMemos) =>
+            prevMemos.map((prevMemo) => {
+              if (prevMemo.id !== memo.id) {
+                return prevMemo;
+              }
+
+              return { ...prevMemo, chatHistoryHeadID: id };
+            }),
+          );
+        },
+      };
     },
+  };
+
+  const transport = new AssistantChatTransport({
+    api: "https://ai-chat-788918986145.asia-northeast1.run.app/",
+    body: async () => {
+      // HTTPリクエストのたびに新しいreCAPTCHA tokenを取得する必要あり
+      await new Promise<void>((resolve) =>
+        grecaptcha.enterprise.ready(resolve),
+      );
+      const recaptchaToken = await grecaptcha.enterprise.execute(
+        "6LeYs_YrAAAAAEUU58gmxMlJR0y9_qYB7YQ0FyIF",
+        { action: "GET_CLIENT_SECRET" },
+      );
+
+      return { recaptchaToken };
+    },
+  });
+
+  const runtime = useRemoteThreadListRuntime({
+    runtimeHook: () =>
+      useChatRuntime({
+        adapters: { history },
+        transport,
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+        onError: (error) => {
+          console.error("Chat request failed", error);
+        },
+      }),
+    adapter: new SingleThreadListAdapter(),
+    threadId: memo.id,
   });
 
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>
-      <ThreadPrimitive.Root>
-        <ThreadPrimitive.Viewport>
-          <AuiIf condition={(state) => state.thread.isEmpty}>
-            <ThreadPrimitive.Suggestions>
-              {() => (
-                <SuggestionPrimitive.Trigger send>
-                  <SuggestionPrimitive.Title />
-                </SuggestionPrimitive.Trigger>
-              )}
-            </ThreadPrimitive.Suggestions>
-          </AuiIf>
-
-          <ThreadPrimitive.Messages>
-            {({ message }) => (
-              <MessagePrimitive.Root>
-                {message.composer.isEditing ? (
-                  <ComposerPrimitive.Root>
-                    <ComposerPrimitive.Input autoFocus />
-
-                    <ComposerPrimitive.Cancel>Cancel</ComposerPrimitive.Cancel>
-                    <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
-                  </ComposerPrimitive.Root>
-                ) : (
-                  <>
-                    <MessagePrimitive.Parts />
-
-                    <ActionBarPrimitive.Root>
-                      {{
-                        system: false,
-                        user: true,
-                        assistant: false,
-                      }[message.role] && (
-                        <ActionBarPrimitive.Edit>Edit</ActionBarPrimitive.Edit>
-                      )}
-                    </ActionBarPrimitive.Root>
-                  </>
+      <Card>
+        <ThreadPrimitive.Root>
+          <ThreadPrimitive.Viewport
+            autoScroll
+            // tailwindcss化
+            style={{ height: 500, overflowY: "auto" }}
+          >
+            <CardContent>
+              <ThreadPrimitive.Suggestions>
+                {() => (
+                  <SuggestionPrimitive.Trigger send>
+                    <SuggestionPrimitive.Title />
+                  </SuggestionPrimitive.Trigger>
                 )}
-              </MessagePrimitive.Root>
-            )}
-          </ThreadPrimitive.Messages>
+              </ThreadPrimitive.Suggestions>
 
-          <ThreadPrimitive.ViewportFooter>
-            <ComposerPrimitive.Root>
-              <ComposerPrimitive.Input placeholder="校正さんに相談する" />
-              <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
-            </ComposerPrimitive.Root>
-          </ThreadPrimitive.ViewportFooter>
-        </ThreadPrimitive.Viewport>
-      </ThreadPrimitive.Root>
+              <ThreadPrimitive.Messages>
+                {({ message }) => (
+                  <MessagePrimitive.Root>
+                    {message.composer.isEditing ? (
+                      <ComposerPrimitive.Root>
+                        <ComposerPrimitive.Input autoFocus />
+
+                        <ComposerPrimitive.Cancel>
+                          Cancel
+                        </ComposerPrimitive.Cancel>
+                        <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+                      </ComposerPrimitive.Root>
+                    ) : (
+                      <>
+                        <MessagePrimitive.Parts />
+
+                        <ActionBarPrimitive.Root>
+                          {{
+                            system: false,
+                            user: true,
+                            assistant: false,
+                          }[message.role] && (
+                            <ActionBarPrimitive.Edit>
+                              Edit
+                            </ActionBarPrimitive.Edit>
+                          )}
+                        </ActionBarPrimitive.Root>
+                      </>
+                    )}
+                  </MessagePrimitive.Root>
+                )}
+              </ThreadPrimitive.Messages>
+
+              <ThreadPrimitive.ViewportFooter>
+                <ComposerPrimitive.Root>
+                  <ComposerPrimitive.Input placeholder="校正さんに相談する" />
+                  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+                </ComposerPrimitive.Root>
+              </ThreadPrimitive.ViewportFooter>
+            </CardContent>
+          </ThreadPrimitive.Viewport>
+        </ThreadPrimitive.Root>
+      </Card>
     </AssistantRuntimeProvider>
   );
 };
-
-/*
-  return <ChatKit control={control} style={{ height: 500 }} />;
-};*/

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -1,6 +1,7 @@
 import {
   ActionBarPrimitive,
   AssistantRuntimeProvider,
+  AuiIf,
   ComposerPrimitive,
   MessagePrimitive,
   Suggestions,
@@ -21,6 +22,12 @@ import {
   useChatRuntime,
 } from "@assistant-ui/react-ai-sdk";
 import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import {
+  PaperAirplaneIcon,
+  PencilSquareIcon,
+  XMarkIcon,
+} from "@heroicons/react/20/solid";
+import CardActions from "@mui/material/CardActions";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
@@ -363,28 +370,50 @@ export const Chat: FunctionComponent<{
         <ThreadPrimitive.Root>
           <ThreadPrimitive.Viewport
             autoScroll
-            className="h-[560px] overflow-y-auto"
+            className="max-h-[560px] overflow-y-auto overscroll-contain"
           >
             <CardContent>
-              <ThreadPrimitive.Suggestions>
-                {() => (
-                  <SuggestionPrimitive.Trigger send>
-                    <SuggestionPrimitive.Title />
-                  </SuggestionPrimitive.Trigger>
-                )}
-              </ThreadPrimitive.Suggestions>
+              <div className="[&:not(:empty)]:mb-3">
+                <ThreadPrimitive.Suggestions>
+                  {() => (
+                    <SuggestionPrimitive.Trigger
+                      send
+                      className="mb-1 w-full rounded-md bg-[#00857E]/10 px-2.5 py-1.5 text-left text-sm text-[#006B66] shadow-xs hover:bg-[#00857E]/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00857E]"
+                    >
+                      <SuggestionPrimitive.Title />
+                    </SuggestionPrimitive.Trigger>
+                  )}
+                </ThreadPrimitive.Suggestions>
+              </div>
 
               <ThreadPrimitive.Messages>
                 {({ message }) => (
-                  <MessagePrimitive.Root>
+                  <MessagePrimitive.Root
+                    className={
+                      message.composer.isEditing
+                        ? undefined
+                        : message.role === "user"
+                          ? "rounded-lg bg-zinc-100 p-3"
+                          : "py-2 text-sm/6 text-zinc-700"
+                    }
+                  >
                     {message.composer.isEditing ? (
-                      <ComposerPrimitive.Root>
-                        <ComposerPrimitive.Input autoFocus />
+                      <ComposerPrimitive.Root className="flex w-full items-end gap-2 rounded-xl border border-zinc-950/10 bg-white p-2 shadow-sm focus-within:ring-2 focus-within:ring-[#00857E]">
+                        <ComposerPrimitive.Input
+                          autoFocus
+                          className="min-h-10 min-w-0 flex-1 resize-none bg-transparent px-2 py-2 text-sm/6 outline-none placeholder:text-zinc-500"
+                        />
 
-                        <ComposerPrimitive.Cancel>
-                          Cancel
-                        </ComposerPrimitive.Cancel>
-                        <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+                        <div className="flex shrink-0 flex-col gap-2">
+                          <ComposerPrimitive.Cancel className="rounded-full p-2 text-zinc-500 hover:bg-zinc-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00857E]">
+                            <XMarkIcon className="size-5" />
+                            <span className="sr-only">キャンセル</span>
+                          </ComposerPrimitive.Cancel>
+                          <ComposerPrimitive.Send className="rounded-full bg-[#00857E] p-2 text-white shadow-sm hover:bg-[#006B66] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00857E] disabled:opacity-50">
+                            <PaperAirplaneIcon className="size-5" />
+                            <span className="sr-only">送信</span>
+                          </ComposerPrimitive.Send>
+                        </div>
                       </ComposerPrimitive.Root>
                     ) : (
                       <>
@@ -395,7 +424,7 @@ export const Chat: FunctionComponent<{
                                 <MarkdownTextPrimitive
                                   remarkPlugins={[remarkGfm]}
                                   defer
-                                  className="prose"
+                                  className="prose prose-sm prose-zinc max-w-none prose-li:pl-0 prose-ol:pl-4 prose-ul:pl-4"
                                 />
                               ),
                               audio: null,
@@ -410,14 +439,15 @@ export const Chat: FunctionComponent<{
                           }
                         </MessagePrimitive.Parts>
 
-                        <ActionBarPrimitive.Root>
+                        <ActionBarPrimitive.Root className="mt-1 flex justify-end">
                           {{
                             system: false,
                             user: true,
                             assistant: false,
                           }[message.role] && (
-                            <ActionBarPrimitive.Edit>
-                              Edit
+                            <ActionBarPrimitive.Edit className="rounded-md p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00857E]">
+                              <PencilSquareIcon className="size-4" />
+                              <span className="sr-only">編集</span>
                             </ActionBarPrimitive.Edit>
                           )}
                         </ActionBarPrimitive.Root>
@@ -427,13 +457,27 @@ export const Chat: FunctionComponent<{
                 )}
               </ThreadPrimitive.Messages>
 
-              <ThreadPrimitive.ViewportFooter>
-                <ComposerPrimitive.Root>
-                  <ComposerPrimitive.Input placeholder="校正さんに相談する" />
-                  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+              <AuiIf condition={(state) => state.thread.isRunning}>
+                <div role="status" className="px-1 py-2 text-sm text-zinc-500">
+                  校正さんが回答しています…
+                </div>
+              </AuiIf>
+            </CardContent>
+
+            <CardActions className="sticky bottom-0 bg-white/95 backdrop-blur">
+              <ThreadPrimitive.ViewportFooter className="w-full">
+                <ComposerPrimitive.Root className="flex w-full items-end gap-2 rounded-xl border border-zinc-950/10 bg-white p-2 shadow-sm focus-within:ring-2 focus-within:ring-[#00857E]">
+                  <ComposerPrimitive.Input
+                    placeholder="校正さんに相談する"
+                    className="min-h-10 flex-1 resize-none bg-transparent px-2 py-2 text-sm/6 outline-none placeholder:text-zinc-500"
+                  />
+                  <ComposerPrimitive.Send className="rounded-full bg-[#00857E] p-2 text-white shadow-sm hover:bg-[#006B66] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00857E] disabled:opacity-50">
+                    <PaperAirplaneIcon className="size-5" />
+                    <span className="sr-only">送信</span>
+                  </ComposerPrimitive.Send>
                 </ComposerPrimitive.Root>
               </ThreadPrimitive.ViewportFooter>
-            </CardContent>
+            </CardActions>
           </ThreadPrimitive.Viewport>
         </ThreadPrimitive.Root>
       </Card>

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -20,11 +20,13 @@ import {
   AssistantChatTransport,
   useChatRuntime,
 } from "@assistant-ui/react-ai-sdk";
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import React, { useMemo } from "react";
 import type { Dispatch, FunctionComponent } from "react";
+import remarkGfm from "remark-gfm";
 import { z } from "zod";
 
 import type { ProofreadingMessage } from "../lintWorker";
@@ -362,7 +364,7 @@ export const Chat: FunctionComponent<{
           <ThreadPrimitive.Viewport
             autoScroll
             // tailwindcss化
-            style={{ height: 500, overflowY: "auto" }}
+            style={{ height: 560, overflowY: "auto" }}
           >
             <CardContent>
               <ThreadPrimitive.Suggestions>
@@ -387,7 +389,27 @@ export const Chat: FunctionComponent<{
                       </ComposerPrimitive.Root>
                     ) : (
                       <>
-                        <MessagePrimitive.Parts />
+                        <MessagePrimitive.Parts>
+                          {({ part }) =>
+                            ({
+                              text: (
+                                // prose入れる
+                                <MarkdownTextPrimitive
+                                  remarkPlugins={[remarkGfm]}
+                                  defer
+                                />
+                              ),
+                              audio: null,
+                              data: null,
+                              file: null,
+                              "generative-ui": null,
+                              image: null,
+                              reasoning: null,
+                              source: null,
+                              "tool-call": null,
+                            })[part.type]
+                          }
+                        </MessagePrimitive.Parts>
 
                         <ActionBarPrimitive.Root>
                           {{

--- a/packages/website/src/Memo/Chat.tsx
+++ b/packages/website/src/Memo/Chat.tsx
@@ -363,8 +363,7 @@ export const Chat: FunctionComponent<{
         <ThreadPrimitive.Root>
           <ThreadPrimitive.Viewport
             autoScroll
-            // tailwindcss化
-            style={{ height: 560, overflowY: "auto" }}
+            className="h-[560px] overflow-y-auto"
           >
             <CardContent>
               <ThreadPrimitive.Suggestions>
@@ -393,10 +392,10 @@ export const Chat: FunctionComponent<{
                           {({ part }) =>
                             ({
                               text: (
-                                // prose入れる
                                 <MarkdownTextPrimitive
                                   remarkPlugins={[remarkGfm]}
                                   defer
+                                  className="prose"
                                 />
                               ),
                               audio: null,

--- a/packages/website/src/Memo/MemoActions.tsx
+++ b/packages/website/src/Memo/MemoActions.tsx
@@ -115,12 +115,12 @@ export const MemoActions: React.FunctionComponent<{
         </CardContent>
       </Card>
 
-      {navigator.onLine && (
-        <Card>
-          <CardContent>
-            {chatEnabled ? (
-              <Chat dispatchMemos={dispatchMemos} memo={memo} memos={memos} />
-            ) : (
+      {navigator.onLine &&
+        (chatEnabled ? (
+          <Chat memo={memo} memos={memos} dispatchMemos={dispatchMemos} />
+        ) : (
+          <Card>
+            <CardContent>
               <Stack alignItems="center" spacing={2}>
                 <img
                   alt=""
@@ -143,10 +143,9 @@ export const MemoActions: React.FunctionComponent<{
                   相談する
                 </Button>
               </Stack>
-            )}
-          </CardContent>
-        </Card>
-      )}
+            </CardContent>
+          </Card>
+        ))}
 
       <SettingDialog
         dispatchSetting={dispatchSetting}

--- a/packages/website/src/Memo/TextContainer/TextContainer.tsx
+++ b/packages/website/src/Memo/TextContainer/TextContainer.tsx
@@ -54,7 +54,7 @@ const MessagePopover = styled(Popover)({
 const PinTarget = styled("button")(({ theme }) => ({
   padding: theme.spacing(1),
   position: "absolute",
-  transform: "translateY(-100%)",
+  transform: "translate(-8px, calc(-100% + 8px))",
   background: "none",
   border: "none",
   cursor: "pointer",
@@ -226,6 +226,7 @@ export const TextContainer: React.FunctionComponent<{
           onBlur={handleTextFieldBlur}
           onChange={handleTextFieldChange}
           onFocus={handleTextFieldFocus}
+          placeholder="メモを入力"
           aria-label="校正する文章"
         />
 

--- a/packages/website/src/index.css
+++ b/packages/website/src/index.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";

--- a/packages/website/src/useMemo.ts
+++ b/packages/website/src/useMemo.ts
@@ -25,7 +25,7 @@ export const createMemo = (): Memo => ({
   updatedAt: new Date().toISOString(),
 });
 
-export const getMemoTitle = (memo: Memo) =>
+export const getMemoTitle = (memo: Pick<Memo, "text">) =>
   memo.text.trim().split("\n")[0] || "(空のメモ)";
 
 export type MemosAction = (prevMemo: Memo[]) => Memo[];

--- a/packages/website/src/useMemo.ts
+++ b/packages/website/src/useMemo.ts
@@ -16,6 +16,7 @@ export interface Memo {
   setting: Setting;
   text: string;
   updatedAt?: string;
+  chatHistoryHeadID?: string;
 }
 
 export const createMemo = (): Memo => ({

--- a/packages/website/webpack.prod.js
+++ b/packages/website/webpack.prod.js
@@ -41,7 +41,7 @@ module.exports = {
       "process.env.TIMESTAMP": JSON.stringify(String(Date.now())),
     }),
     new webpack.ProvidePlugin({
-      process: "process/browser",
+      process: "process/browser.js",
     }),
   ],
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,50 +2,110 @@
 # yarn lockfile v1
 
 
-"@assistant-ui/core@^0.2.20":
-  version "0.2.20"
-  resolved "https://npm.flatt.tech/@assistant-ui/core/-/core-0.2.20.tgz#1000e19fd1627b8ca26a340d8e947349cde87dd1"
-  integrity sha512-PVUQH+Q3uQ98eSIeuY4gVR1zD1dhF0nkIQ9A3unE8BFPQD5iLXWkgSq+iAhF3H7WqKpTjUDhvJUAanAPcxqWfQ==
+"@ai-sdk/gateway@4.0.23":
+  version "4.0.23"
+  resolved "https://npm.flatt.tech/@ai-sdk/gateway/-/gateway-4.0.23.tgz#4177fcfdead4044576c50c9ef40fac37e1f95a85"
+  integrity sha512-f85diFdPMXYJpxCjOYZchMQkRH8h3r6lhK4Q2xmzJ7UA2OQ80L3W7tFu61742xGQK7zHWm5AhxYhNuc50H9SGQ==
   dependencies:
-    assistant-stream "^0.3.25"
-    nanoid "^5.1.15"
+    "@ai-sdk/provider" "4.0.3"
+    "@ai-sdk/provider-utils" "5.0.11"
+    "@vercel/oidc" "3.2.0"
 
-"@assistant-ui/react@^0.14.26":
-  version "0.14.26"
-  resolved "https://npm.flatt.tech/@assistant-ui/react/-/react-0.14.26.tgz#805b709416140ceaa0c850b62abc746bc40d3a4b"
-  integrity sha512-i5BaJOe5hwSEr3mt89RsURfSGGJlCNJg3Vlh3Dw2PVeQr6MAGchT80v7aLf3e8LJ5IroKLhG8PyPCfYr1NV9XQ==
+"@ai-sdk/mcp@2.0.15", "@ai-sdk/mcp@^2.0.13":
+  version "2.0.15"
+  resolved "https://npm.flatt.tech/@ai-sdk/mcp/-/mcp-2.0.15.tgz#ba18c8e60e78788d73ac52de1bf6618d2859c11b"
+  integrity sha512-JIwbud+pMM6GgXDhwm5/lSpg7y8kAO1JHJ4NQEmfST6nXy3Gijaxy4LIrKqVR/1N5VPZAfwOdSsUWtbtTp6zZw==
   dependencies:
-    "@assistant-ui/core" "^0.2.20"
-    "@assistant-ui/store" "^0.2.19"
-    "@assistant-ui/tap" "^0.9.3"
-    "@radix-ui/primitive" "^1.1.4"
-    "@radix-ui/react-collection" "^1.1.10"
+    "@ai-sdk/provider" "4.0.3"
+    "@ai-sdk/provider-utils" "5.0.11"
+    pkce-challenge "^5.0.1"
+
+"@ai-sdk/provider-utils@5.0.11":
+  version "5.0.11"
+  resolved "https://npm.flatt.tech/@ai-sdk/provider-utils/-/provider-utils-5.0.11.tgz#e084d9f46f9f2297baabc5f004b92c45e82d4eee"
+  integrity sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==
+  dependencies:
+    "@ai-sdk/provider" "4.0.3"
+    "@standard-schema/spec" "^1.1.0"
+    "@workflow/serde" "4.1.0"
+    eventsource-parser "^3.0.8"
+
+"@ai-sdk/provider@4.0.3":
+  version "4.0.3"
+  resolved "https://npm.flatt.tech/@ai-sdk/provider/-/provider-4.0.3.tgz#308624f81547a73556a67dc2465bf6f1d67fb77f"
+  integrity sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/react@^4.0.30":
+  version "4.0.34"
+  resolved "https://npm.flatt.tech/@ai-sdk/react/-/react-4.0.34.tgz#c98267cb72c7a74361c96b987cca068cf8c51296"
+  integrity sha512-yrMJecJUwS18oGHUWPemuDBy9elVIjxbLsqNg6nraPu+TO7e5QFTv1ma9kLhKy4FGvDJW0Ff4Z57sKEsIlYZeA==
+  dependencies:
+    "@ai-sdk/mcp" "2.0.15"
+    "@ai-sdk/provider" "4.0.3"
+    "@ai-sdk/provider-utils" "5.0.11"
+    ai "7.0.31"
+    swr "^2.4.1"
+    throttleit "2.1.0"
+
+"@assistant-ui/core@^0.2.21":
+  version "0.2.21"
+  resolved "https://npm.flatt.tech/@assistant-ui/core/-/core-0.2.21.tgz#621ffed754849773a952b4f302ee5ca336df1dd7"
+  integrity sha512-Kwv9EywvtTsvoSmqFS0uonsQmN9iuo0GaIpqPGkxnfu4o8/slMw8gNDFNc+2+mzAdNCXcwkkLxh52gws7vhf0w==
+  dependencies:
+    assistant-stream "^0.3.26"
+    nanoid "^6.0.0"
+
+"@assistant-ui/react-ai-sdk@^1.3.41":
+  version "1.3.41"
+  resolved "https://npm.flatt.tech/@assistant-ui/react-ai-sdk/-/react-ai-sdk-1.3.41.tgz#8d785f7481fbe0cdb833731adb17402ffcbcf420"
+  integrity sha512-WLwdaIXfk+w48dXUY2BtwKTQjktwGh1PSRPjzYwAXi+iPBxFJBgz4Tz0oW8mP6RetM/Q3qC6v9K/1059Pm/94g==
+  dependencies:
+    "@ai-sdk/mcp" "^2.0.13"
+    "@ai-sdk/react" "^4.0.30"
+    "@assistant-ui/core" "^0.2.21"
+    "@assistant-ui/store" "^0.2.20"
+    ai "^7.0.28"
+    assistant-cloud "*"
+    assistant-stream "^0.3.26"
+
+"@assistant-ui/react@^0.14.27":
+  version "0.14.27"
+  resolved "https://npm.flatt.tech/@assistant-ui/react/-/react-0.14.27.tgz#612dfa1d20d08eb5333009c700886f19e148ab2e"
+  integrity sha512-zV49HS6+pxu3BLdTI8TCH2j6vrx7aQtgJFmsPjfs6JVrahKvCojIUDF8dhpfzUtMyfi6VFrrXe496x319bqoDQ==
+  dependencies:
+    "@assistant-ui/core" "^0.2.21"
+    "@assistant-ui/store" "^0.2.20"
+    "@assistant-ui/tap" "^0.9.4"
+    "@radix-ui/primitive" "^1.1.5"
+    "@radix-ui/react-collection" "^1.1.12"
     "@radix-ui/react-compose-refs" "^1.1.3"
-    "@radix-ui/react-context" "^1.1.4"
-    "@radix-ui/react-primitive" "^2.1.6"
+    "@radix-ui/react-context" "^1.2.0"
+    "@radix-ui/react-primitive" "^2.1.7"
     "@radix-ui/react-use-callback-ref" "^1.1.2"
     "@radix-ui/react-use-controllable-state" "^1.2.3"
-    "@radix-ui/react-use-escape-keydown" "^1.1.2"
-    assistant-cloud "^0.1.34"
-    assistant-stream "^0.3.25"
-    nanoid "^5.1.15"
-    radix-ui "^1.6.0"
+    "@radix-ui/react-use-escape-keydown" "^1.1.3"
+    assistant-cloud "^0.1.35"
+    assistant-stream "^0.3.26"
+    nanoid "^6.0.0"
+    radix-ui "^1.6.2"
     react-textarea-autosize "^8.5.9"
-    safe-content-frame "^0.0.22"
+    safe-content-frame "^0.0.23"
     zod "^4.4.3"
     zustand "^5.0.14"
 
-"@assistant-ui/store@^0.2.19":
-  version "0.2.19"
-  resolved "https://npm.flatt.tech/@assistant-ui/store/-/store-0.2.19.tgz#039d04ebe11bb244a86c8228f5af35d9c268792c"
-  integrity sha512-7GMEoK+H4iINquteLFXqqDB5SAzB19YHBy4KKQprxHseAtDrpkC8w9pTrPfJ1yLvbn3FqjXk645bCt5vDf1sTg==
+"@assistant-ui/store@^0.2.20":
+  version "0.2.20"
+  resolved "https://npm.flatt.tech/@assistant-ui/store/-/store-0.2.20.tgz#2fad96fbeb58d871515b7e1223890ef0c3d8dbcf"
+  integrity sha512-g+iHnov+JMZmVAPKhfs9YqCXWFcCBWCyi+oqsc/kAR9zMsE0+qbE36iyRYfsJFrhMDm+6Ev7/2UTO+1HwTiZfA==
   dependencies:
     use-effect-event "^2.0.3"
 
-"@assistant-ui/tap@^0.9.3":
-  version "0.9.3"
-  resolved "https://npm.flatt.tech/@assistant-ui/tap/-/tap-0.9.3.tgz#0b21ca1a4f3b4ac39e76cd68261fee91dc53cc0c"
-  integrity sha512-IKIgDbaKUPvVt2hMKL+WU2E8oru5J3muO9iSjL/vEVf6TNz5H07wrOKwD+1xhitqR1Nc4WtHK986jqoeGmWRDw==
+"@assistant-ui/tap@^0.9.4":
+  version "0.9.4"
+  resolved "https://npm.flatt.tech/@assistant-ui/tap/-/tap-0.9.4.tgz#c168461e21cb0f11bc779707320dd796beef1089"
+  integrity sha512-l44CfXvWrokaXQWBGsFGf574rlM9h5ii9mbcSJ8VoPV6KIpK5zlRqhkSxWWKuke4Q70tQygLaZm1BdiPwIP0bA==
 
 "@azu/format-text@^1.0.1", "@azu/format-text@^1.0.2":
   version "1.0.2"
@@ -819,7 +879,7 @@
   resolved "https://npm.flatt.tech/@radix-ui/number/-/number-1.1.2.tgz#3ace52303a4a570d03dc79bf17d6da49ed40d0cf"
   integrity sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==
 
-"@radix-ui/primitive@1.1.5", "@radix-ui/primitive@^1.1.4":
+"@radix-ui/primitive@1.1.5", "@radix-ui/primitive@^1.1.5":
   version "1.1.5"
   resolved "https://npm.flatt.tech/@radix-ui/primitive/-/primitive-1.1.5.tgz#cfeb31acbf332c72eb0b13831963c21ad6ca3e32"
   integrity sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==
@@ -910,7 +970,7 @@
     "@radix-ui/react-use-controllable-state" "1.2.3"
     "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-collection@1.1.12", "@radix-ui/react-collection@^1.1.10":
+"@radix-ui/react-collection@1.1.12", "@radix-ui/react-collection@^1.1.12":
   version "1.1.12"
   resolved "https://npm.flatt.tech/@radix-ui/react-collection/-/react-collection-1.1.12.tgz#1ca96614de0643b39f786f6545c3db0b0e7daa8c"
   integrity sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==
@@ -936,7 +996,7 @@
     "@radix-ui/react-primitive" "2.1.7"
     "@radix-ui/react-use-controllable-state" "1.2.3"
 
-"@radix-ui/react-context@1.2.0", "@radix-ui/react-context@^1.1.4":
+"@radix-ui/react-context@1.2.0", "@radix-ui/react-context@^1.2.0":
   version "1.2.0"
   resolved "https://npm.flatt.tech/@radix-ui/react-context/-/react-context-1.2.0.tgz#81e75eb5bdeb55bbe019547f13fb5c78598d44e2"
   integrity sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==
@@ -1189,7 +1249,7 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-primitive@2.1.7", "@radix-ui/react-primitive@^2.1.6":
+"@radix-ui/react-primitive@2.1.7", "@radix-ui/react-primitive@^2.1.7":
   version "2.1.7"
   resolved "https://npm.flatt.tech/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz#1f487a06434770f865dbfb6c9a55bbefcbad8c82"
   integrity sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==
@@ -1429,7 +1489,7 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-use-escape-keydown@1.1.3", "@radix-ui/react-use-escape-keydown@^1.1.2":
+"@radix-ui/react-use-escape-keydown@1.1.3", "@radix-ui/react-use-escape-keydown@^1.1.3":
   version "1.1.3"
   resolved "https://npm.flatt.tech/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.3.tgz#4271bb071201242e24e2a6a6267ea20525b2184e"
   integrity sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==
@@ -1888,6 +1948,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@vercel/oidc@3.2.0":
+  version "3.2.0"
+  resolved "https://npm.flatt.tech/@vercel/oidc/-/oidc-3.2.0.tgz#5782a4d4904443f015808705b5537cf9c3b68528"
+  integrity sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==
+
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.14.1.tgz#a9f6a07f2b03c95c8d38c4536a1fdfb521ff55b6"
@@ -2024,6 +2089,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
+"@workflow/serde@4.1.0":
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/@workflow/serde/-/serde-4.1.0.tgz#82dbbaf2370f7b8ae46d9a9a4ab0917258f8db62"
+  integrity sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -2066,6 +2136,15 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+ai@7.0.31, ai@^7.0.28:
+  version "7.0.31"
+  resolved "https://npm.flatt.tech/ai/-/ai-7.0.31.tgz#d8e6b919fa1ed5e98310fe92626cdd9852ab8b48"
+  integrity sha512-pJfwKXjF5kw0rKRTePwYo60EfWb8wfzJAgf3ojln/YkOsVVKttzZAJVcRPsg37Z3a06ZdKkxX+DSrMAFlPm5Mw==
+  dependencies:
+    "@ai-sdk/gateway" "4.0.23"
+    "@ai-sdk/provider" "4.0.3"
+    "@ai-sdk/provider-utils" "5.0.11"
 
 ajv-formats@^2.1.1:
   version "2.1.1"
@@ -2261,20 +2340,20 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-assistant-cloud@^0.1.34:
-  version "0.1.34"
-  resolved "https://npm.flatt.tech/assistant-cloud/-/assistant-cloud-0.1.34.tgz#290bb23d8180eaa196dc058f958533061887c1f1"
-  integrity sha512-kmB9qJmwf1Kb3FoLvVnDV7lsT2vRwaiNX9iDoEs+3Gli8aOQ667DPUIXvEXPyV5zF4gfT0E7GFNEcYWRQTElAA==
+assistant-cloud@*, assistant-cloud@^0.1.35:
+  version "0.1.35"
+  resolved "https://npm.flatt.tech/assistant-cloud/-/assistant-cloud-0.1.35.tgz#22fb2028737ac3971c10b0476eb9c5d0d8bd669d"
+  integrity sha512-SiMvAXalCwM9GcnyIiJfQTZda00E2VE/jZWqSdX4WPxQyHeVNK7uBzw3AaFpBQT1vXbS1UYdKVlZdUJ3vRftCg==
   dependencies:
-    assistant-stream "^0.3.24"
+    assistant-stream "^0.3.26"
 
-assistant-stream@^0.3.24, assistant-stream@^0.3.25:
-  version "0.3.25"
-  resolved "https://npm.flatt.tech/assistant-stream/-/assistant-stream-0.3.25.tgz#847adbb7ff216d836af953e02b4359d14fb43078"
-  integrity sha512-hOShVxlctNPWbGF4B1BqwM9Snp8NdS13F7sBIfhkCxlKDdX67/ylxNlGLVcB0E24V/U8XM0GlfS9DsVrxRsn8A==
+assistant-stream@^0.3.26:
+  version "0.3.26"
+  resolved "https://npm.flatt.tech/assistant-stream/-/assistant-stream-0.3.26.tgz#e7471544b3bb2733c972bba7f4c258e392c948d1"
+  integrity sha512-qjYrK9c5Mpuz3U6oG6YDpBbiICANhNTN86MLNcI47iRYXalqvCZL2Tzmh9pQcGWDX3PltSJtGIFAIHdRDXIg+A==
   dependencies:
     "@standard-schema/spec" "^1.1.0"
-    nanoid "^5.1.15"
+    nanoid "^6.0.0"
     secure-json-parse "^4.1.0"
 
 astral-regex@^2.0.0:
@@ -2928,6 +3007,11 @@ depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-node-es@^1.1.0:
   version "1.1.0"
   resolved "https://npm.flatt.tech/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
@@ -3196,6 +3280,11 @@ eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.3.tgz#e9af1d40b77e6268cdcbc767321e8b9f066adea8"
   integrity sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==
+
+eventsource-parser@^3.0.8:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/eventsource-parser/-/eventsource-parser-3.1.0.tgz#4e198eb91cd333d0a8ddcc036502b3618a25f449"
+  integrity sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==
 
 eventsource@^3.0.2:
   version "3.0.7"
@@ -4195,6 +4284,11 @@ json-schema-typed@^8.0.2:
   resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
   integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
+json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://npm.flatt.tech/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -4824,10 +4918,10 @@ nan@^2.22.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.0.tgz#24aa4ddffcc37613a2d2935b97683c1ec96093c6"
   integrity sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==
 
-nanoid@^5.1.15:
-  version "5.1.16"
-  resolved "https://npm.flatt.tech/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
-  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
+nanoid@^6.0.0:
+  version "6.0.0"
+  resolved "https://npm.flatt.tech/nanoid/-/nanoid-6.0.0.tgz#8a07398e87773c6a97d158921cad826a9c344eab"
+  integrity sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ==
 
 negotiator@^1.0.0:
   version "1.0.0"
@@ -5212,6 +5306,11 @@ pkce-challenge@^5.0.0:
   resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.0.tgz#c3a405cb49e272094a38e890a2b51da0228c4d97"
   integrity sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==
 
+pkce-challenge@^5.0.1:
+  version "5.0.1"
+  resolved "https://npm.flatt.tech/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -5325,7 +5424,7 @@ quote@0.4.0:
   resolved "https://registry.yarnpkg.com/quote/-/quote-0.4.0.tgz#10839217f6c1362b89194044d29b233fd7f32f01"
   integrity sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=
 
-radix-ui@^1.6.0:
+radix-ui@^1.6.2:
   version "1.6.2"
   resolved "https://npm.flatt.tech/radix-ui/-/radix-ui-1.6.2.tgz#580cbcf185dcd4ec5e86677b98134f52ddfaf88f"
   integrity sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==
@@ -5724,10 +5823,10 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-content-frame@^0.0.22:
-  version "0.0.22"
-  resolved "https://npm.flatt.tech/safe-content-frame/-/safe-content-frame-0.0.22.tgz#c38ebacd93b24589c69a32718b1adaad5584f100"
-  integrity sha512-RHZ4pcF0FWnqIjUmqlGwKxmkFvmQ/qZcJ5p5glhOe+VlfgdPadiKVWQRUXV6Q5/PiTDX2UmGK2alJQQArU6HUA==
+safe-content-frame@^0.0.23:
+  version "0.0.23"
+  resolved "https://npm.flatt.tech/safe-content-frame/-/safe-content-frame-0.0.23.tgz#a95bde43aee45f0b97e34a7f1a4d1514de2b1dab"
+  integrity sha512-iIxZS0aEyYXp2CazwEeu1qhvar4sOctzjZQSlfvXzeGEqIpeCThXW1dV2t6HJ3FiixgWiDqdFMKzBq0mOCDmEQ==
 
 safe-regex-test@^1.1.0:
   version "1.1.0"
@@ -6257,6 +6356,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+swr@^2.4.1:
+  version "2.4.2"
+  resolved "https://npm.flatt.tech/swr/-/swr-2.4.2.tgz#741ba9c804db756cfa966376cbc33f84a2d88cfd"
+  integrity sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==
+  dependencies:
+    dequal "^2.0.3"
+    use-sync-external-store "^1.6.0"
 
 syllable@^3.4.0:
   version "3.6.1"
@@ -6834,6 +6941,11 @@ textlint@^15.2.0:
     unique-concat "^0.2.2"
     zod "^3.25.67"
 
+throttleit@2.1.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
+  integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
+
 tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
@@ -7131,6 +7243,11 @@ use-sidecar@^1.1.3:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://npm.flatt.tech/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 util-deprecate@^1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,51 @@
 # yarn lockfile v1
 
 
+"@assistant-ui/core@^0.2.20":
+  version "0.2.20"
+  resolved "https://npm.flatt.tech/@assistant-ui/core/-/core-0.2.20.tgz#1000e19fd1627b8ca26a340d8e947349cde87dd1"
+  integrity sha512-PVUQH+Q3uQ98eSIeuY4gVR1zD1dhF0nkIQ9A3unE8BFPQD5iLXWkgSq+iAhF3H7WqKpTjUDhvJUAanAPcxqWfQ==
+  dependencies:
+    assistant-stream "^0.3.25"
+    nanoid "^5.1.15"
+
+"@assistant-ui/react@^0.14.26":
+  version "0.14.26"
+  resolved "https://npm.flatt.tech/@assistant-ui/react/-/react-0.14.26.tgz#805b709416140ceaa0c850b62abc746bc40d3a4b"
+  integrity sha512-i5BaJOe5hwSEr3mt89RsURfSGGJlCNJg3Vlh3Dw2PVeQr6MAGchT80v7aLf3e8LJ5IroKLhG8PyPCfYr1NV9XQ==
+  dependencies:
+    "@assistant-ui/core" "^0.2.20"
+    "@assistant-ui/store" "^0.2.19"
+    "@assistant-ui/tap" "^0.9.3"
+    "@radix-ui/primitive" "^1.1.4"
+    "@radix-ui/react-collection" "^1.1.10"
+    "@radix-ui/react-compose-refs" "^1.1.3"
+    "@radix-ui/react-context" "^1.1.4"
+    "@radix-ui/react-primitive" "^2.1.6"
+    "@radix-ui/react-use-callback-ref" "^1.1.2"
+    "@radix-ui/react-use-controllable-state" "^1.2.3"
+    "@radix-ui/react-use-escape-keydown" "^1.1.2"
+    assistant-cloud "^0.1.34"
+    assistant-stream "^0.3.25"
+    nanoid "^5.1.15"
+    radix-ui "^1.6.0"
+    react-textarea-autosize "^8.5.9"
+    safe-content-frame "^0.0.22"
+    zod "^4.4.3"
+    zustand "^5.0.14"
+
+"@assistant-ui/store@^0.2.19":
+  version "0.2.19"
+  resolved "https://npm.flatt.tech/@assistant-ui/store/-/store-0.2.19.tgz#039d04ebe11bb244a86c8228f5af35d9c268792c"
+  integrity sha512-7GMEoK+H4iINquteLFXqqDB5SAzB19YHBy4KKQprxHseAtDrpkC8w9pTrPfJ1yLvbn3FqjXk645bCt5vDf1sTg==
+  dependencies:
+    use-effect-event "^2.0.3"
+
+"@assistant-ui/tap@^0.9.3":
+  version "0.9.3"
+  resolved "https://npm.flatt.tech/@assistant-ui/tap/-/tap-0.9.3.tgz#0b21ca1a4f3b4ac39e76cd68261fee91dc53cc0c"
+  integrity sha512-IKIgDbaKUPvVt2hMKL+WU2E8oru5J3muO9iSjL/vEVf6TNz5H07wrOKwD+1xhitqR1Nc4WtHK986jqoeGmWRDw==
+
 "@azu/format-text@^1.0.1", "@azu/format-text@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@azu/format-text/-/format-text-1.0.2.tgz#abd46dab2422e312bd1bfe36f0d427ab6039825d"
@@ -287,6 +332,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
+"@babel/runtime@^7.20.13":
+  version "7.29.7"
+  resolved "https://npm.flatt.tech/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
@@ -441,6 +491,33 @@
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
+
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://npm.flatt.tech/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://npm.flatt.tech/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.8"
+  resolved "https://npm.flatt.tech/@floating-ui/react-dom/-/react-dom-2.1.8.tgz#5fb5a20d10aafb9505f38c24f38d00c8e1598893"
+  integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
+  dependencies:
+    "@floating-ui/dom" "^1.7.6"
+
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://npm.flatt.tech/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
 "@hono/node-server@^1.19.9":
   version "1.19.13"
@@ -727,18 +804,6 @@
   dependencies:
     semver "^7.3.5"
 
-"@openai/chatkit-react@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@openai/chatkit-react/-/chatkit-react-1.5.0.tgz#200e47d9d2d462cc10a25e4892518b5c3bb6f74c"
-  integrity sha512-3HnQrkEqJEJ75N0rNaArwzgLPOrTd/FwnNfGVbqRaCTq2/Eb9aHLXQzMXyNYBA5ORUiwZl3FyFqpFieG0f9YUQ==
-  dependencies:
-    "@openai/chatkit" "1.6.0"
-
-"@openai/chatkit@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@openai/chatkit/-/chatkit-1.6.0.tgz#95f65b87e44fde855650ec04ebd1e930f0795cc5"
-  integrity sha512-lV19ocIYI7EPvP4ZpKNOtoJFmZpyf4DB5472rRd6ua7TE22ENEy0Vbi4OSCJzSD8hBa/v6KyF77qxIV7I1paAg==
-
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -748,6 +813,674 @@
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@radix-ui/number@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/number/-/number-1.1.2.tgz#3ace52303a4a570d03dc79bf17d6da49ed40d0cf"
+  integrity sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==
+
+"@radix-ui/primitive@1.1.5", "@radix-ui/primitive@^1.1.4":
+  version "1.1.5"
+  resolved "https://npm.flatt.tech/@radix-ui/primitive/-/primitive-1.1.5.tgz#cfeb31acbf332c72eb0b13831963c21ad6ca3e32"
+  integrity sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==
+
+"@radix-ui/react-accessible-icon@1.1.11":
+  version "1.1.11"
+  resolved "https://npm.flatt.tech/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.11.tgz#fbb237c180c06ed03cff8a5cdecd57ba11fd4b60"
+  integrity sha512-HQDOFTKwSnmUij6l54wYJJtxTAnxI71+YJLOrjm2ladFB8HAV5Jt7hwaZPhWTGBkYoW4+ZAOfNZrLDh/qvxSYA==
+  dependencies:
+    "@radix-ui/react-visually-hidden" "1.2.7"
+
+"@radix-ui/react-accordion@1.2.16":
+  version "1.2.16"
+  resolved "https://npm.flatt.tech/@radix-ui/react-accordion/-/react-accordion-1.2.16.tgz#f383dc8d2baabbd55cda9fe13ff44ecb1e900433"
+  integrity sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collapsible" "1.1.16"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-alert-dialog@1.1.19":
+  version "1.1.19"
+  resolved "https://npm.flatt.tech/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.19.tgz#323ba7b370e805013c5e6557e5f70cd051e4b05b"
+  integrity sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dialog" "1.1.19"
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-arrow@1.1.11":
+  version "1.1.11"
+  resolved "https://npm.flatt.tech/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz#be2a068bffe4453bd6941fc44eed1f1ea0e8226f"
+  integrity sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-aspect-ratio@1.1.11":
+  version "1.1.11"
+  resolved "https://npm.flatt.tech/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.11.tgz#ab1e5df733f3ec4271c96b06ea7017517e74a9d8"
+  integrity sha512-IUAhIVpBUvP5NNICjlaB1OFmtRLGqQqTF3ZOSGPoq3XeLXRFtHiWTRxSVEULgOd9GQR2c7tsYqDnhUennapZnw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-avatar@1.2.2":
+  version "1.2.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-avatar/-/react-avatar-1.2.2.tgz#d8c4ef4e713b84bbbdaff1dad467d67d77519890"
+  integrity sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==
+  dependencies:
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-is-hydrated" "0.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-checkbox@1.3.7":
+  version "1.3.7"
+  resolved "https://npm.flatt.tech/@radix-ui/react-checkbox/-/react-checkbox-1.3.7.tgz#481da0046052ca1abf59208c6c64ec4dc32adfae"
+  integrity sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-collapsible@1.1.16":
+  version "1.1.16"
+  resolved "https://npm.flatt.tech/@radix-ui/react-collapsible/-/react-collapsible-1.1.16.tgz#747c7ec2ef1357fc3b4f4e2a73717bdb76f8cd8f"
+  integrity sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-collection@1.1.12", "@radix-ui/react-collection@^1.1.10":
+  version "1.1.12"
+  resolved "https://npm.flatt.tech/@radix-ui/react-collection/-/react-collection-1.1.12.tgz#1ca96614de0643b39f786f6545c3db0b0e7daa8c"
+  integrity sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+
+"@radix-ui/react-compose-refs@1.1.3", "@radix-ui/react-compose-refs@^1.1.3":
+  version "1.1.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz#5f1e61e1a5f52800d31e7f8affa6d046e38f50d1"
+  integrity sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==
+
+"@radix-ui/react-context-menu@2.3.3":
+  version "2.3.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-context-menu/-/react-context-menu-2.3.3.tgz#91fe6b345f573f257ab844a8503acb9a2a74f234"
+  integrity sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-menu" "2.1.20"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-context@1.2.0", "@radix-ui/react-context@^1.1.4":
+  version "1.2.0"
+  resolved "https://npm.flatt.tech/@radix-ui/react-context/-/react-context-1.2.0.tgz#81e75eb5bdeb55bbe019547f13fb5c78598d44e2"
+  integrity sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==
+
+"@radix-ui/react-dialog@1.1.19":
+  version "1.1.19"
+  resolved "https://npm.flatt.tech/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz#ecdf153deb213c2d92ac02e10955dd288ceb3b3e"
+  integrity sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
+"@radix-ui/react-direction@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-direction/-/react-direction-1.1.2.tgz#9cc69edd659d79fba4101ee0e2dbcffc2024504f"
+  integrity sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==
+
+"@radix-ui/react-dismissable-layer@1.1.15":
+  version "1.1.15"
+  resolved "https://npm.flatt.tech/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz#accf8c7b6ec77e7544d2f6c411426d453ca66bcb"
+  integrity sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+
+"@radix-ui/react-dropdown-menu@2.1.20":
+  version "2.1.20"
+  resolved "https://npm.flatt.tech/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.20.tgz#dfc4a2fb67a382aed43d26f8d2717bf2d3a393a6"
+  integrity sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-menu" "2.1.20"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-focus-guards@1.1.4":
+  version "1.1.4"
+  resolved "https://npm.flatt.tech/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz#3ef07a117ae7aa1430442aaebd766507e69d391c"
+  integrity sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==
+
+"@radix-ui/react-focus-scope@1.1.12":
+  version "1.1.12"
+  resolved "https://npm.flatt.tech/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz#5a8b099c80271a0667ff2e74b25ced3ea58e8ee3"
+  integrity sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+
+"@radix-ui/react-form@0.1.12":
+  version "0.1.12"
+  resolved "https://npm.flatt.tech/@radix-ui/react-form/-/react-form-0.1.12.tgz#0e995376e507588646ced826339f7636444177fa"
+  integrity sha512-JTX94E4LDL91rzLg7X0mHPdxr0A8JEdVwZEmeOwZJSMDHCGW5DFtSlTSJozUyUs807IQmnvbfzKZFVCK5DmkqQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-label" "2.1.11"
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-hover-card@1.1.19":
+  version "1.1.19"
+  resolved "https://npm.flatt.tech/@radix-ui/react-hover-card/-/react-hover-card-1.1.19.tgz#0dc9e395c9d830cd32191946067725339509bbf9"
+  integrity sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-id@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-id/-/react-id-1.1.2.tgz#6fe97e7289c7133b44f8c9c61fdddf2a6be1421d"
+  integrity sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-label@2.1.11":
+  version "2.1.11"
+  resolved "https://npm.flatt.tech/@radix-ui/react-label/-/react-label-2.1.11.tgz#dafdacfe284326ea64eaefa1d329b9809e02f9c0"
+  integrity sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-menu@2.1.20":
+  version "2.1.20"
+  resolved "https://npm.flatt.tech/@radix-ui/react-menu/-/react-menu-2.1.20.tgz#67416e26e9f0d64e724b8216fca84e68b369cc92"
+  integrity sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
+"@radix-ui/react-menubar@1.1.20":
+  version "1.1.20"
+  resolved "https://npm.flatt.tech/@radix-ui/react-menubar/-/react-menubar-1.1.20.tgz#d3a8057b0268897033a73db05f3a7ce97d8985b7"
+  integrity sha512-gzFZvybgmwYsFBWDqanycIoEYnhyk8MMnuLamdFVHUZYGp4COM+sqXiwbnn0VMWqGLeeU7GV7jm+dXRa+Wufag==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-menu" "2.1.20"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-navigation-menu@1.2.18":
+  version "1.2.18"
+  resolved "https://npm.flatt.tech/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.18.tgz#23ef0d2d2cbe9263205a770aa4a0e2351c445cbd"
+  integrity sha512-K9HiuxZ6xCwSaHcIuUpxyhy4w5gpwzWjh9dHTSbMN3Ix4qAyVObS9RlU3zMycb0PO3v9Tpk0BXMwWvXOUbVXew==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-visually-hidden" "1.2.7"
+
+"@radix-ui/react-one-time-password-field@0.1.12":
+  version "0.1.12"
+  resolved "https://npm.flatt.tech/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.12.tgz#5eec165461b64b390239f8aa8b4c6599203f1e30"
+  integrity sha512-nQLu5OAcORDQp1EHAv6k3mJGV1hjMTw2NTGVAsGE1g/mWeNqAd1R5jyaAs3U+A8ZD/W8XNPY2yKT0ZdQnqo3NA==
+  dependencies:
+    "@radix-ui/number" "1.1.2"
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+    "@radix-ui/react-use-is-hydrated" "0.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-password-toggle-field@0.1.7":
+  version "0.1.7"
+  resolved "https://npm.flatt.tech/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.7.tgz#22d633f78a71b8c4f776f2365111e39c7ebe9af5"
+  integrity sha512-gB1Mr8vzdv1XzDjrtJTXmL0JORRs1B4g7ngUs0F+H2VvMOwXTZMTmLCl0wZZ3m7ylX8TssI7NCvgiSHmLuTm/A==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+    "@radix-ui/react-use-is-hydrated" "0.1.1"
+
+"@radix-ui/react-popover@1.1.19":
+  version "1.1.19"
+  resolved "https://npm.flatt.tech/@radix-ui/react-popover/-/react-popover-1.1.19.tgz#c3c29d5f0be101f36d4d89bda6796f33e1a1de4a"
+  integrity sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
+"@radix-ui/react-popper@1.3.3":
+  version "1.3.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-popper/-/react-popper-1.3.3.tgz#3f27f929118d8cb8ffced905d33fa887b9e1432b"
+  integrity sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.11"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-rect" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+    "@radix-ui/rect" "1.1.2"
+
+"@radix-ui/react-portal@1.1.13":
+  version "1.1.13"
+  resolved "https://npm.flatt.tech/@radix-ui/react-portal/-/react-portal-1.1.13.tgz#8b80b8b33ef4fff449c6d3ab62492f4dca162c7e"
+  integrity sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-presence@1.1.7":
+  version "1.1.7"
+  resolved "https://npm.flatt.tech/@radix-ui/react-presence/-/react-presence-1.1.7.tgz#42b69b29984fb6431338988615bc8b9767814dad"
+  integrity sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-primitive@2.1.7", "@radix-ui/react-primitive@^2.1.6":
+  version "2.1.7"
+  resolved "https://npm.flatt.tech/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz#1f487a06434770f865dbfb6c9a55bbefcbad8c82"
+  integrity sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.3.0"
+
+"@radix-ui/react-progress@1.1.12":
+  version "1.1.12"
+  resolved "https://npm.flatt.tech/@radix-ui/react-progress/-/react-progress-1.1.12.tgz#b827f000d5cd70dee9887f973ec0000138ca0253"
+  integrity sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==
+  dependencies:
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-radio-group@1.4.3":
+  version "1.4.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-radio-group/-/react-radio-group-1.4.3.tgz#5c7cd85cd607f892ea022b78bf01dfe5597f80f2"
+  integrity sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-roving-focus@1.1.15":
+  version "1.1.15"
+  resolved "https://npm.flatt.tech/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz#fd24daf2b849b201c5e2626e1bf8bcbc57f6a715"
+  integrity sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-is-hydrated" "0.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-scroll-area@1.2.14":
+  version "1.2.14"
+  resolved "https://npm.flatt.tech/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.14.tgz#c1182ee1494f9666a4beae5ae1523dfdab75505a"
+  integrity sha512-bBODCWZK7JTbQLHs0uIP4f73wIWatakK4OS33UzkR1x897wu0PuO658a3f+6P2GEGyDzGYMuHRatMVoAk9WZTw==
+  dependencies:
+    "@radix-ui/number" "1.1.2"
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-select@2.3.3":
+  version "2.3.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-select/-/react-select-2.3.3.tgz#4dbe0554543d481c82c4d2a867641663962bacb8"
+  integrity sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==
+  dependencies:
+    "@radix-ui/number" "1.1.2"
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-visually-hidden" "1.2.7"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
+"@radix-ui/react-separator@1.1.11":
+  version "1.1.11"
+  resolved "https://npm.flatt.tech/@radix-ui/react-separator/-/react-separator-1.1.11.tgz#f023c006c5372742175617293b0b692790024956"
+  integrity sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-slider@1.4.3":
+  version "1.4.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-slider/-/react-slider-1.4.3.tgz#1f07ed15343f3b3efe5bdb571318d86a298365da"
+  integrity sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==
+  dependencies:
+    "@radix-ui/number" "1.1.2"
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-slot@1.3.0":
+  version "1.3.0"
+  resolved "https://npm.flatt.tech/@radix-ui/react-slot/-/react-slot-1.3.0.tgz#e311c7a6c8d65b1af9e69af8e3318c6c7105a212"
+  integrity sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+
+"@radix-ui/react-switch@1.3.3":
+  version "1.3.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-switch/-/react-switch-1.3.3.tgz#1caf4e29983fdc76eb6da61d8cbd61d86d9143cd"
+  integrity sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-tabs@1.1.17":
+  version "1.1.17"
+  resolved "https://npm.flatt.tech/@radix-ui/react-tabs/-/react-tabs-1.1.17.tgz#e236f55e8bd88e5a0bb493628379c57b5bfc4436"
+  integrity sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-toast@1.2.19":
+  version "1.2.19"
+  resolved "https://npm.flatt.tech/@radix-ui/react-toast/-/react-toast-1.2.19.tgz#ce751105c18f128fb3464accd76187107ea4d9fb"
+  integrity sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-visually-hidden" "1.2.7"
+
+"@radix-ui/react-toggle-group@1.1.15":
+  version "1.1.15"
+  resolved "https://npm.flatt.tech/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.15.tgz#15666c92f26cd1c8cd3547b1de67645958136e62"
+  integrity sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-toggle" "1.1.14"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-toggle@1.1.14":
+  version "1.1.14"
+  resolved "https://npm.flatt.tech/@radix-ui/react-toggle/-/react-toggle-1.1.14.tgz#76323bdbbb2791009b938b83658a3e7ace00fbcf"
+  integrity sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-toolbar@1.1.15":
+  version "1.1.15"
+  resolved "https://npm.flatt.tech/@radix-ui/react-toolbar/-/react-toolbar-1.1.15.tgz#3cd1abd8528d0974bfb7f2844a6ca70a690bb3fc"
+  integrity sha512-t/iEuVjUnXXtrsGK40AA43uIx37sn3AqZ7oAVnPICK6lFJP6dzMzWR3U9b6eCfFjb6wtSEqkJ9Rn9xDjiOx20g==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-separator" "1.1.11"
+    "@radix-ui/react-toggle-group" "1.1.15"
+
+"@radix-ui/react-tooltip@1.2.12":
+  version "1.2.12"
+  resolved "https://npm.flatt.tech/@radix-ui/react-tooltip/-/react-tooltip-1.2.12.tgz#f38a646eda98036e66fd33fc4725621e2f7aa812"
+  integrity sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-visually-hidden" "1.2.7"
+
+"@radix-ui/react-use-callback-ref@1.1.2", "@radix-ui/react-use-callback-ref@^1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz#ddc0bc1381ff3b62368c248808efc45a098bafde"
+  integrity sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==
+
+"@radix-ui/react-use-controllable-state@1.2.3", "@radix-ui/react-use-controllable-state@^1.2.3":
+  version "1.2.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz#516996f6443207546aa15a59bc71cdf5b54e01d1"
+  integrity sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-use-effect-event@0.0.3":
+  version "0.0.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz#e8f45e8e6ef64ce5bea7b5a9effc373f067e3530"
+  integrity sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-use-escape-keydown@1.1.3", "@radix-ui/react-use-escape-keydown@^1.1.2":
+  version "1.1.3"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.3.tgz#4271bb071201242e24e2a6a6267ea20525b2184e"
+  integrity sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+
+"@radix-ui/react-use-is-hydrated@0.1.1":
+  version "0.1.1"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz#61a18cb03430a6d2e704eb2afd3067505ed0f292"
+  integrity sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==
+
+"@radix-ui/react-use-layout-effect@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz#c882e66497174d061f250e65251974b699c65b65"
+  integrity sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==
+
+"@radix-ui/react-use-previous@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz#8fd78d5874de9c150e7b21ab1a411d5bc1a26257"
+  integrity sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==
+
+"@radix-ui/react-use-rect@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz#83b9de1ea8f6abd1425eb79f2930e00047cb8d19"
+  integrity sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==
+  dependencies:
+    "@radix-ui/rect" "1.1.2"
+
+"@radix-ui/react-use-size@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz#33eb275755424d7dda33ffa32c23ea85ca23be40"
+  integrity sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-visually-hidden@1.2.7":
+  version "1.2.7"
+  resolved "https://npm.flatt.tech/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz#64fc5994ebd39b3b19f4e93c11da22bf03af684b"
+  integrity sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/rect@1.1.2":
+  version "1.1.2"
+  resolved "https://npm.flatt.tech/@radix-ui/rect/-/rect-1.1.2.tgz#0761a82af55c7e302d5b509eaf1c97ea1fc5feea"
+  integrity sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://npm.flatt.tech/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@textlint-ja/textlint-rule-no-dropping-i@hata6502/textlint-rule-no-dropping-i":
   version "1.0.1"
@@ -1492,6 +2225,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.2.4:
+  version "1.2.6"
+  resolved "https://npm.flatt.tech/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
+  dependencies:
+    tslib "^2.0.0"
+
 array-find-index@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -1520,6 +2260,22 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+assistant-cloud@^0.1.34:
+  version "0.1.34"
+  resolved "https://npm.flatt.tech/assistant-cloud/-/assistant-cloud-0.1.34.tgz#290bb23d8180eaa196dc058f958533061887c1f1"
+  integrity sha512-kmB9qJmwf1Kb3FoLvVnDV7lsT2vRwaiNX9iDoEs+3Gli8aOQ667DPUIXvEXPyV5zF4gfT0E7GFNEcYWRQTElAA==
+  dependencies:
+    assistant-stream "^0.3.24"
+
+assistant-stream@^0.3.24, assistant-stream@^0.3.25:
+  version "0.3.25"
+  resolved "https://npm.flatt.tech/assistant-stream/-/assistant-stream-0.3.25.tgz#847adbb7ff216d836af953e02b4359d14fb43078"
+  integrity sha512-hOShVxlctNPWbGF4B1BqwM9Snp8NdS13F7sBIfhkCxlKDdX67/ylxNlGLVcB0E24V/U8XM0GlfS9DsVrxRsn8A==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    nanoid "^5.1.15"
+    secure-json-parse "^4.1.0"
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -2172,6 +2928,11 @@ depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://npm.flatt.tech/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -2726,6 +3487,11 @@ get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
     has-symbols "^1.1.0"
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://npm.flatt.tech/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-proto@^1.0.0, get-proto@^1.0.1:
   version "1.0.1"
@@ -3523,7 +4289,6 @@ kind-of@^6.0.0, kind-of@^6.0.2:
 
 kuromoji@0.1.2, kuromoji@hata6502/kuromoji.js:
   version "0.1.8"
-  uid f923005d219a5529fbd92ea8c225700fb40e9366
   resolved "https://codeload.github.com/hata6502/kuromoji.js/tar.gz/f923005d219a5529fbd92ea8c225700fb40e9366"
   dependencies:
     async "^2.0.1"
@@ -3531,7 +4296,6 @@ kuromoji@0.1.2, kuromoji@hata6502/kuromoji.js:
 
 kuromojin@^1.0.2, kuromojin@^1.2.1, kuromojin@^1.4.0, kuromojin@^2.0.0, kuromojin@^2.1.1, kuromojin@^3.0.0, kuromojin@hata6502/kuromojin:
   version "3.0.1"
-  uid d36dc9c33550a326f5574188328c3c233849c982
   resolved "https://codeload.github.com/hata6502/kuromojin/tar.gz/d36dc9c33550a326f5574188328c3c233849c982"
   dependencies:
     kuromoji "0.1.2"
@@ -4060,6 +4824,11 @@ nan@^2.22.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.0.tgz#24aa4ddffcc37613a2d2935b97683c1ec96093c6"
   integrity sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==
 
+nanoid@^5.1.15:
+  version "5.1.16"
+  resolved "https://npm.flatt.tech/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
+
 negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
@@ -4482,7 +5251,6 @@ prettier@^3.6.2:
 
 prh@^5.4.4, prh@hata6502/prh:
   version "5.4.6"
-  uid "88b497e336bac5cc53393b370a41909e90f8b496"
   resolved "https://codeload.github.com/hata6502/prh/tar.gz/88b497e336bac5cc53393b370a41909e90f8b496"
   dependencies:
     commandpost "^1.2.1"
@@ -4556,6 +5324,67 @@ quote@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/quote/-/quote-0.4.0.tgz#10839217f6c1362b89194044d29b233fd7f32f01"
   integrity sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=
+
+radix-ui@^1.6.0:
+  version "1.6.2"
+  resolved "https://npm.flatt.tech/radix-ui/-/radix-ui-1.6.2.tgz#580cbcf185dcd4ec5e86677b98134f52ddfaf88f"
+  integrity sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-accessible-icon" "1.1.11"
+    "@radix-ui/react-accordion" "1.2.16"
+    "@radix-ui/react-alert-dialog" "1.1.19"
+    "@radix-ui/react-arrow" "1.1.11"
+    "@radix-ui/react-aspect-ratio" "1.1.11"
+    "@radix-ui/react-avatar" "1.2.2"
+    "@radix-ui/react-checkbox" "1.3.7"
+    "@radix-ui/react-collapsible" "1.1.16"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-context-menu" "2.3.3"
+    "@radix-ui/react-dialog" "1.1.19"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-dropdown-menu" "2.1.20"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-form" "0.1.12"
+    "@radix-ui/react-hover-card" "1.1.19"
+    "@radix-ui/react-label" "2.1.11"
+    "@radix-ui/react-menu" "2.1.20"
+    "@radix-ui/react-menubar" "1.1.20"
+    "@radix-ui/react-navigation-menu" "1.2.18"
+    "@radix-ui/react-one-time-password-field" "0.1.12"
+    "@radix-ui/react-password-toggle-field" "0.1.7"
+    "@radix-ui/react-popover" "1.1.19"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-progress" "1.1.12"
+    "@radix-ui/react-radio-group" "1.4.3"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-scroll-area" "1.2.14"
+    "@radix-ui/react-select" "2.3.3"
+    "@radix-ui/react-separator" "1.1.11"
+    "@radix-ui/react-slider" "1.4.3"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-switch" "1.3.3"
+    "@radix-ui/react-tabs" "1.1.17"
+    "@radix-ui/react-toast" "1.2.19"
+    "@radix-ui/react-toggle" "1.1.14"
+    "@radix-ui/react-toggle-group" "1.1.15"
+    "@radix-ui/react-toolbar" "1.1.15"
+    "@radix-ui/react-tooltip" "1.2.12"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+    "@radix-ui/react-use-escape-keydown" "1.1.3"
+    "@radix-ui/react-use-is-hydrated" "0.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+    "@radix-ui/react-visually-hidden" "1.2.7"
 
 ramda@0.27.1:
   version "0.27.1"
@@ -4644,6 +5473,42 @@ react-is@^19.0.0, react-is@^19.1.1, react-is@^19.2.0:
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.0.tgz#ddc3b4a4e0f3336c3847f18b806506388d7b9973"
   integrity sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==
+
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://npm.flatt.tech/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.7.2:
+  version "2.7.2"
+  resolved "https://npm.flatt.tech/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.3"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.3"
+
+react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
+  version "2.2.3"
+  resolved "https://npm.flatt.tech/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
+    tslib "^2.0.0"
+
+react-textarea-autosize@^8.5.9:
+  version "8.5.9"
+  resolved "https://npm.flatt.tech/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz#ab8627b09aa04d8a2f45d5b5cd94c84d1d4a8893"
+  integrity sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -4859,6 +5724,11 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safe-content-frame@^0.0.22:
+  version "0.0.22"
+  resolved "https://npm.flatt.tech/safe-content-frame/-/safe-content-frame-0.0.22.tgz#c38ebacd93b24589c69a32718b1adaad5584f100"
+  integrity sha512-RHZ4pcF0FWnqIjUmqlGwKxmkFvmQ/qZcJ5p5glhOe+VlfgdPadiKVWQRUXV6Q5/PiTDX2UmGK2alJQQArU6HUA==
+
 safe-regex-test@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
@@ -4894,6 +5764,11 @@ schema-utils@^4.0.0, schema-utils@^4.3.0, schema-utils@^4.3.3:
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+secure-json-parse@^4.1.0:
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/secure-json-parse/-/secure-json-parse-4.1.0.tgz#4f1ab41c67a13497ea1b9131bb4183a22865477c"
+  integrity sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==
 
 semver@^6.3.1:
   version "6.3.1"
@@ -5357,7 +6232,6 @@ stylis@4.2.0:
 
 sudachi-synonyms-dictionary@hata6502/sudachi-synonyms-dictionary:
   version "6.0.1"
-  uid e6aa3ea4c0581e2c1f6f06361ed72cd260f69851
   resolved "https://codeload.github.com/hata6502/sudachi-synonyms-dictionary/tar.gz/e6aa3ea4c0581e2c1f6f06361ed72cd260f69851"
 
 supports-color@^2.0.0:
@@ -5796,7 +6670,6 @@ textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet@^1.0.1:
 
 textlint-rule-no-nfd@^1.0.1, textlint-rule-no-nfd@^1.0.2, textlint-rule-no-nfd@hata6502/textlint-rule-no-nfd:
   version "1.0.3"
-  uid "400d1a254ca856ed945d0f3f244458fc4d28048d"
   resolved "https://codeload.github.com/hata6502/textlint-rule-no-nfd/tar.gz/400d1a254ca856ed945d0f3f244458fc4d28048d"
   dependencies:
     match-index "^1.0.3"
@@ -5809,7 +6682,6 @@ textlint-rule-no-zero-width-spaces@^1.0.0, textlint-rule-no-zero-width-spaces@^1
 
 textlint-rule-prefer-tari-tari@^1.0.3, textlint-rule-prefer-tari-tari@hata6502/textlint-rule-prefer-tari-tari:
   version "1.0.4"
-  uid "91dc2af97d68dbfc9e17e3d84555708d8f9e2a38"
   resolved "https://codeload.github.com/hata6502/textlint-rule-prefer-tari-tari/tar.gz/91dc2af97d68dbfc9e17e3d84555708d8f9e2a38"
   dependencies:
     nlcst-parse-japanese "^1.1.2"
@@ -6011,6 +6883,11 @@ trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
+tslib@^2.0.0, tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://npm.flatt.tech/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -6217,6 +7094,43 @@ url-regex-safe@^1.0.2:
     ip-regex "^4.3.0"
     re2 "1.15.4"
     tlds "^1.217.0"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://npm.flatt.tech/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
+use-composed-ref@^1.3.0:
+  version "1.4.0"
+  resolved "https://npm.flatt.tech/use-composed-ref/-/use-composed-ref-1.4.0.tgz#09e023bf798d005286ad85cd20674bdf5770653b"
+  integrity sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==
+
+use-effect-event@^2.0.3:
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/use-effect-event/-/use-effect-event-2.0.3.tgz#9e013702d37dc9f8930c7717d9cfdb3804b23240"
+  integrity sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.2.1"
+  resolved "https://npm.flatt.tech/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz#2f11a525628f56424521c748feabc2ffcc962fce"
+  integrity sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==
+
+use-latest@^1.2.1:
+  version "1.3.0"
+  resolved "https://npm.flatt.tech/use-latest/-/use-latest-1.3.0.tgz#549b9b0d4c1761862072f0899c6f096eb379137a"
+  integrity sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==
+  dependencies:
+    use-isomorphic-layout-effect "^1.1.1"
+
+use-sidecar@^1.1.3:
+  version "1.1.3"
+  resolved "https://npm.flatt.tech/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 util-deprecate@^1.0.1:
   version "1.0.2"
@@ -6476,6 +7390,16 @@ zod@^4.1.12:
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.12.tgz#64f1ea53d00eab91853195653b5af9eee68970f0"
   integrity sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==
+
+zod@^4.4.3:
+  version "4.4.3"
+  resolved "https://npm.flatt.tech/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
+
+zustand@^5.0.14:
+  version "5.0.14"
+  resolved "https://npm.flatt.tech/zustand/-/zustand-5.0.14.tgz#18216c24fcb980cf36898f9c57520e67b1f77855"
+  integrity sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==
 
 zwitch@^1.0.0:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,7 +2137,7 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
-ai@7.0.31, ai@^7.0.28:
+ai@7.0.31, ai@^7.0.28, ai@^7.0.31:
   version "7.0.31"
   resolved "https://npm.flatt.tech/ai/-/ai-7.0.31.tgz#d8e6b919fa1ed5e98310fe92626cdd9852ab8b48"
   integrity sha512-pJfwKXjF5kw0rKRTePwYo60EfWb8wfzJAgf3ojln/YkOsVVKttzZAJVcRPsg37Z3a06ZdKkxX+DSrMAFlPm5Mw==
@@ -7502,11 +7502,6 @@ zod@^3.25.67:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
-
-zod@^4.1.12:
-  version "4.1.12"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.12.tgz#64f1ea53d00eab91853195653b5af9eee68970f0"
-  integrity sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==
 
 zod@^4.4.3:
   version "4.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,16 @@
     assistant-cloud "*"
     assistant-stream "^0.3.26"
 
+"@assistant-ui/react-markdown@^0.14.6":
+  version "0.14.6"
+  resolved "https://npm.flatt.tech/@assistant-ui/react-markdown/-/react-markdown-0.14.6.tgz#bdfc3269376202f365450e36ed1f79a7ae75861c"
+  integrity sha512-4H9C3gbmdUDTJhVVo/1bwDBRC0Ctz0zX9kBgUKhGD2FLhdzOBFHHZdohjf6pRcb7qG7eRD/PprhqdW4kFf+42w==
+  dependencies:
+    "@radix-ui/react-primitive" "^2.1.7"
+    "@radix-ui/react-use-callback-ref" "^1.1.2"
+    classnames "^2.5.1"
+    react-markdown "^10.1.0"
+
 "@assistant-ui/react@^0.14.27":
   version "0.14.27"
   resolved "https://npm.flatt.tech/@assistant-ui/react/-/react-0.14.27.tgz#612dfa1d20d08eb5333009c700886f19e148ab2e"
@@ -1858,6 +1868,13 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.30.tgz#dc1e40f7af3b9c815013a7860e6252f6352a84df"
   integrity sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==
 
+"@types/debug@^4.0.0":
+  version "4.1.13"
+  resolved "https://npm.flatt.tech/@types/debug/-/debug-4.1.13.tgz#22d1cc9d542d3593caea764f974306ab36286ee7"
+  integrity sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -1874,15 +1891,34 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
+"@types/estree-jsx@^1.0.0":
+  version "1.0.5"
+  resolved "https://npm.flatt.tech/@types/estree-jsx/-/estree-jsx-1.0.5.tgz#858a88ea20f34fe65111f005a689fa1ebf70dc18"
+  integrity sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==
+  dependencies:
+    "@types/estree" "*"
+
 "@types/estree@*", "@types/estree@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
+"@types/estree@^1.0.0":
+  version "1.0.9"
+  resolved "https://npm.flatt.tech/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
+
 "@types/grecaptcha@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@types/grecaptcha/-/grecaptcha-3.0.9.tgz#9f3b07ec06c8fff221aa6fc124fe5b8a0e2c3349"
   integrity sha512-fFxMtjAvXXMYTzDFK5NpcVB7WHnrHVLl00QzEGpuFxSAC789io6M+vjcn+g5FTEamIJtJr/IHkCDsqvJxeWDyw==
+
+"@types/hast@^3.0.0":
+  version "3.0.5"
+  resolved "https://npm.flatt.tech/@types/hast/-/hast-3.0.5.tgz#48020de4c0e63492f4ca9db42068c108f68b7f8f"
+  integrity sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==
+  dependencies:
+    "@types/unist" "*"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -1895,6 +1931,18 @@
   integrity sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==
   dependencies:
     "@types/unist" "^2"
+
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://npm.flatt.tech/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
+
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node@*":
   version "16.4.1"
@@ -1938,6 +1986,11 @@
   resolved "https://registry.yarnpkg.com/@types/structured-source/-/structured-source-3.0.0.tgz#e95d76037d400c1957f3b709f023b308e92f3829"
   integrity sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA==
 
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.3"
+  resolved "https://npm.flatt.tech/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
+
 "@types/unist@^2":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
@@ -1947,6 +2000,11 @@
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
+"@ungap/structured-clone@^1.0.0":
+  version "1.3.3"
+  resolved "https://npm.flatt.tech/@ungap/structured-clone/-/structured-clone-1.3.3.tgz#094041e1a4cb1987f038335421281ac8be390bcc"
+  integrity sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==
 
 "@vercel/oidc@3.2.0":
   version "3.2.0"
@@ -2407,6 +2465,11 @@ bail@^1.0.0:
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://npm.flatt.tech/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -2609,6 +2672,11 @@ ccount@^1.0.0, ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
 chalk-template@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
@@ -2645,20 +2713,40 @@ chalk@^5.0.1:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
 character-entities-legacy@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
   integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
 
 character-entities@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
   integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
 
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://npm.flatt.tech/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
 character-reference-invalid@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
+character-reference-invalid@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
 charenc@0.0.2:
   version "0.0.2"
@@ -2693,6 +2781,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 cli-boxes@^3.0.0:
   version "3.0.0"
@@ -2756,6 +2849,11 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
 commander@^10.0.1:
   version "10.0.1"
@@ -2947,6 +3045,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+decode-named-character-reference@^1.0.0:
+  version "1.3.0"
+  resolved "https://npm.flatt.tech/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz#3e40603760874c2e5867691b599d73a7da25b53f"
+  integrity sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==
+  dependencies:
+    character-entities "^2.0.0"
+
 deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -3007,7 +3112,7 @@ depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-dequal@^2.0.3:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://npm.flatt.tech/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -3016,6 +3121,13 @@ detect-node-es@^1.1.0:
   version "1.1.0"
   resolved "https://npm.flatt.tech/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
+devlop@^1.0.0, devlop@^1.1.0:
+  version "1.1.0"
+  resolved "https://npm.flatt.tech/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
 
 diff@^4.0.1:
   version "4.0.2"
@@ -3226,6 +3338,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://npm.flatt.tech/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -3255,6 +3372,11 @@ estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estree-util-is-identifier-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz#0b5ef4c4ff13508b34dcd01ecfa945f61fce5dbd"
+  integrity sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==
 
 estree-walker@^0.5.0:
   version "0.5.2"
@@ -3730,6 +3852,34 @@ hast-util-parse-selector@^2.0.0:
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
   integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
 
+hast-util-to-jsx-runtime@^2.0.0:
+  version "2.3.6"
+  resolved "https://npm.flatt.tech/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
+  integrity sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    estree-util-is-identifier-name "^3.0.0"
+    hast-util-whitespace "^3.0.0"
+    mdast-util-mdx-expression "^2.0.0"
+    mdast-util-mdx-jsx "^3.0.0"
+    mdast-util-mdxjs-esm "^2.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-js "^1.0.0"
+    unist-util-position "^5.0.0"
+    vfile-message "^4.0.0"
+
+hast-util-whitespace@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 hastscript@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-5.1.2.tgz#bde2c2e56d04c62dd24e8c5df288d050a355fb8a"
@@ -3763,6 +3913,11 @@ hosted-git-info@^7.0.0:
   integrity sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==
   dependencies:
     lru-cache "^10.0.1"
+
+html-url-attributes@^3.0.0:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
+  integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
 
 http-cache-semantics@^4.1.1:
   version "4.2.0"
@@ -3877,6 +4032,11 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+inline-style-parser@0.2.7:
+  version "0.2.7"
+  resolved "https://npm.flatt.tech/inline-style-parser/-/inline-style-parser-0.2.7.tgz#b1fc68bfc0313b8685745e4464e37f9376b9c909"
+  integrity sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==
+
 install-artifact-from-github@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/install-artifact-from-github/-/install-artifact-from-github-1.4.0.tgz#ad705b4ddceb4b820e946f03cd6d34ead98279fb"
@@ -3922,6 +4082,11 @@ is-alphabetical@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
   integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
 
+is-alphabetical@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
+
 is-alphanumerical@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
@@ -3929,6 +4094,14 @@ is-alphanumerical@^1.0.0:
   dependencies:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
+
+is-alphanumerical@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  integrity sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==
+  dependencies:
+    is-alphabetical "^2.0.0"
+    is-decimal "^2.0.0"
 
 is-arguments@^1.0.4:
   version "1.1.0"
@@ -4012,6 +4185,11 @@ is-decimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
   integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
+is-decimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
+
 is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
@@ -4072,6 +4250,11 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
+is-hexadecimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
+
 is-in-browser@^1.0.2, is-in-browser@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
@@ -4104,6 +4287,11 @@ is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+is-plain-obj@^4.0.0:
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-plain-object@^2.0.4:
   version "2.0.4"
@@ -4467,6 +4655,11 @@ longest-streak@^2.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
+longest-streak@^3.0.0:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
+
 loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -4520,6 +4713,11 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
+markdown-table@^3.0.0:
+  version "3.0.4"
+  resolved "https://npm.flatt.tech/markdown-table/-/markdown-table-3.0.4.tgz#fe44d6d410ff9d6f2ea1797a3f60aa4d2b631c2a"
+  integrity sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==
+
 match-index@^1.0.1, match-index@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/match-index/-/match-index-1.0.3.tgz#752ec60c6586ea5dd440d5e62cfbff25838c071a"
@@ -4550,6 +4748,16 @@ mdast-util-find-and-replace@^1.1.0:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
+mdast-util-find-and-replace@^3.0.0:
+  version "3.0.2"
+  resolved "https://npm.flatt.tech/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz#70a3174c894e14df722abf43bc250cbae44b11df"
+  integrity sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    escape-string-regexp "^5.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
 mdast-util-footnote@^0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/mdast-util-footnote/-/mdast-util-footnote-0.1.7.tgz#4b226caeab4613a3362c144c94af0fdd6f7e0ef0"
@@ -4569,6 +4777,24 @@ mdast-util-from-markdown@^0.8.0:
     parse-entities "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
+mdast-util-from-markdown@^2.0.0:
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz#c95822b91aab75f18a4cbe8b2f51b873ed2cf0c7"
+  integrity sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark "^4.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-stringify-position "^4.0.0"
+
 mdast-util-frontmatter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz#8bd5cd55e236c03e204a036f7372ebe9e6748240"
@@ -4585,12 +4811,43 @@ mdast-util-gfm-autolink-literal@^0.1.0, mdast-util-gfm-autolink-literal@^0.1.3:
     mdast-util-find-and-replace "^1.1.0"
     micromark "^2.11.3"
 
+mdast-util-gfm-autolink-literal@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz#abd557630337bd30a6d5a4bd8252e1c2dc0875d5"
+  integrity sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    ccount "^2.0.0"
+    devlop "^1.0.0"
+    mdast-util-find-and-replace "^3.0.0"
+    micromark-util-character "^2.0.0"
+
+mdast-util-gfm-footnote@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz#7778e9d9ca3df7238cc2bd3fa2b1bf6a65b19403"
+  integrity sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.1.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+
 mdast-util-gfm-strikethrough@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz#45eea337b7fff0755a291844fbea79996c322890"
   integrity sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==
   dependencies:
     mdast-util-to-markdown "^0.6.0"
+
+mdast-util-gfm-strikethrough@^2.0.0:
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz#d44ef9e8ed283ac8c1165ab0d0dfd058c2764c16"
+  integrity sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
 
 mdast-util-gfm-table@^0.1.0:
   version "0.1.6"
@@ -4600,12 +4857,33 @@ mdast-util-gfm-table@^0.1.0:
     markdown-table "^2.0.0"
     mdast-util-to-markdown "~0.6.0"
 
+mdast-util-gfm-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz#7a435fb6223a72b0862b33afbd712b6dae878d38"
+  integrity sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    markdown-table "^3.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
 mdast-util-gfm-task-list-item@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz#70c885e6b9f543ddd7e6b41f9703ee55b084af10"
   integrity sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==
   dependencies:
     mdast-util-to-markdown "~0.6.0"
+
+mdast-util-gfm-task-list-item@^2.0.0:
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz#e68095d2f8a4303ef24094ab642e1047b991a936"
+  integrity sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
 
 mdast-util-gfm@^0.1.0:
   version "0.1.2"
@@ -4617,6 +4895,84 @@ mdast-util-gfm@^0.1.0:
     mdast-util-gfm-table "^0.1.0"
     mdast-util-gfm-task-list-item "^0.1.0"
     mdast-util-to-markdown "^0.6.1"
+
+mdast-util-gfm@^3.0.0:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz#2cdf63b92c2a331406b0fb0db4c077c1b0331751"
+  integrity sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==
+  dependencies:
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-gfm-autolink-literal "^2.0.0"
+    mdast-util-gfm-footnote "^2.0.0"
+    mdast-util-gfm-strikethrough "^2.0.0"
+    mdast-util-gfm-table "^2.0.0"
+    mdast-util-gfm-task-list-item "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdx-expression@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz#43f0abac9adc756e2086f63822a38c8d3c3a5096"
+  integrity sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdx-jsx@^3.0.0:
+  version "3.2.0"
+  resolved "https://npm.flatt.tech/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz#fd04c67a2a7499efb905a8a5c578dddc9fdada0d"
+  integrity sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    devlop "^1.1.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    parse-entities "^4.0.0"
+    stringify-entities "^4.0.0"
+    unist-util-stringify-position "^4.0.0"
+    vfile-message "^4.0.0"
+
+mdast-util-mdxjs-esm@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz#019cfbe757ad62dd557db35a695e7314bcc9fa97"
+  integrity sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-phrasing@^4.0.0:
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
+  integrity sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    unist-util-is "^6.0.0"
+
+mdast-util-to-hast@^13.0.0:
+  version "13.2.1"
+  resolved "https://npm.flatt.tech/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz#d7ff84ca499a57e2c060ae67548ad950e689a053"
+  integrity sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    trim-lines "^3.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
 
 mdast-util-to-markdown@^0.6.0, mdast-util-to-markdown@^0.6.1, mdast-util-to-markdown@~0.6.0:
   version "0.6.5"
@@ -4630,10 +4986,32 @@ mdast-util-to-markdown@^0.6.0, mdast-util-to-markdown@^0.6.1, mdast-util-to-mark
     repeat-string "^1.0.0"
     zwitch "^1.0.0"
 
+mdast-util-to-markdown@^2.0.0:
+  version "2.1.2"
+  resolved "https://npm.flatt.tech/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz#f910ffe60897f04bb4b7e7ee434486f76288361b"
+  integrity sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-phrasing "^4.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    unist-util-visit "^5.0.0"
+    zwitch "^2.0.0"
+
 mdast-util-to-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
   integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
+
+mdast-util-to-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://npm.flatt.tech/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
 
 media-typer@^1.1.0:
   version "1.1.0"
@@ -4655,6 +5033,28 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+micromark-core-commonmark@^2.0.0:
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz#c691630e485021a68cf28dbc2b2ca27ebf678cd4"
+  integrity sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-destination "^2.0.0"
+    micromark-factory-label "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-factory-title "^2.0.0"
+    micromark-factory-whitespace "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-html-tag-name "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
 micromark-extension-footnote@^0.3.0:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/micromark-extension-footnote/-/micromark-extension-footnote-0.3.2.tgz#129b74ef4920ce96719b2c06102ee7abb2b88a20"
@@ -4669,12 +5069,48 @@ micromark-extension-frontmatter@^0.2.0:
   dependencies:
     fault "^1.0.0"
 
+micromark-extension-gfm-autolink-literal@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz#6286aee9686c4462c1e3552a9d505feddceeb935"
+  integrity sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
 micromark-extension-gfm-autolink-literal@~0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz#53866c1f0c7ef940ae7ca1f72c6faef8fed9f204"
   integrity sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==
   dependencies:
     micromark "~2.11.3"
+
+micromark-extension-gfm-footnote@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz#4dab56d4e398b9853f6fe4efac4fc9361f3e0750"
+  integrity sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-strikethrough@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz#86106df8b3a692b5f6a92280d3879be6be46d923"
+  integrity sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromark-extension-gfm-strikethrough@~0.6.5:
   version "0.6.5"
@@ -4683,6 +5119,17 @@ micromark-extension-gfm-strikethrough@~0.6.5:
   dependencies:
     micromark "~2.11.0"
 
+micromark-extension-gfm-table@^2.0.0:
+  version "2.1.1"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz#fac70bcbf51fe65f5f44033118d39be8a9b5940b"
+  integrity sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
 micromark-extension-gfm-table@~0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz#4d49f1ce0ca84996c853880b9446698947f1802b"
@@ -4690,10 +5137,28 @@ micromark-extension-gfm-table@~0.4.0:
   dependencies:
     micromark "~2.11.0"
 
+micromark-extension-gfm-tagfilter@^2.0.0:
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz#f26d8a7807b5985fba13cf61465b58ca5ff7dc57"
+  integrity sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
 micromark-extension-gfm-tagfilter@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz#d9f26a65adee984c9ccdd7e182220493562841ad"
   integrity sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==
+
+micromark-extension-gfm-task-list-item@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz#bcc34d805639829990ec175c3eea12bb5b781f2c"
+  integrity sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromark-extension-gfm-task-list-item@~0.3.0:
   version "0.3.3"
@@ -4714,6 +5179,169 @@ micromark-extension-gfm@^0.3.0:
     micromark-extension-gfm-tagfilter "~0.3.0"
     micromark-extension-gfm-task-list-item "~0.3.0"
 
+micromark-extension-gfm@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz#3e13376ab95dd7a5cfd0e29560dfe999657b3c5b"
+  integrity sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==
+  dependencies:
+    micromark-extension-gfm-autolink-literal "^2.0.0"
+    micromark-extension-gfm-footnote "^2.0.0"
+    micromark-extension-gfm-strikethrough "^2.0.0"
+    micromark-extension-gfm-table "^2.0.0"
+    micromark-extension-gfm-tagfilter "^2.0.0"
+    micromark-extension-gfm-task-list-item "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-destination@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz#8fef8e0f7081f0474fbdd92deb50c990a0264639"
+  integrity sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-label@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz#5267efa97f1e5254efc7f20b459a38cb21058ba1"
+  integrity sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-space@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz#36d0212e962b2b3121f8525fc7a3c7c029f334fc"
+  integrity sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-title@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz#237e4aa5d58a95863f01032d9ee9b090f1de6e94"
+  integrity sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-whitespace@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz#06b26b2983c4d27bfcc657b33e25134d4868b0b1"
+  integrity sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://npm.flatt.tech/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-chunked@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz#47fbcd93471a3fccab86cff03847fc3552db1051"
+  integrity sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-classify-character@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz#d399faf9c45ca14c8b4be98b1ea481bced87b629"
+  integrity sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-combine-extensions@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz#2a0f490ab08bff5cc2fd5eec6dd0ca04f89b30a9"
+  integrity sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==
+  dependencies:
+    micromark-util-chunked "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-decode-numeric-character-reference@^2.0.0:
+  version "2.0.2"
+  resolved "https://npm.flatt.tech/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz#fcf15b660979388e6f118cdb6bf7d79d73d26fe5"
+  integrity sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-decode-string@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz#6cb99582e5d271e84efca8e61a807994d7161eb2"
+  integrity sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-html-tag-name@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz#e40403096481986b41c106627f98f72d4d10b825"
+  integrity sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==
+
+micromark-util-normalize-identifier@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz#c30d77b2e832acf6526f8bf1aa47bc9c9438c16d"
+  integrity sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-resolve-all@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz#e1a2d62cdd237230a2ae11839027b19381e31e8b"
+  integrity sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-subtokenize@^2.0.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz#d8ade5ba0f3197a1cf6a2999fbbfe6357a1a19ee"
+  integrity sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.2"
+  resolved "https://npm.flatt.tech/micromark-util-types/-/micromark-util-types-2.0.2.tgz#f00225f5f5a0ebc3254f96c36b6605c4b393908e"
+  integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+
 micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
   version "2.11.4"
   resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
@@ -4721,6 +5349,29 @@ micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
   dependencies:
     debug "^4.0.0"
     parse-entities "^2.0.0"
+
+micromark@^4.0.0:
+  version "4.0.2"
+  resolved "https://npm.flatt.tech/micromark/-/micromark-4.0.2.tgz#91395a3e1884a198e62116e33c9c568e39936fdb"
+  integrity sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromatch@^4.0.8:
   version "4.0.8"
@@ -5204,6 +5855,19 @@ parse-entities@^2.0.0:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+parse-entities@^4.0.0:
+  version "4.0.2"
+  resolved "https://npm.flatt.tech/parse-entities/-/parse-entities-4.0.2.tgz#61d46f5ed28e4ee62e9ddc43d6b010188443f159"
+  integrity sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    character-entities-legacy "^3.0.0"
+    character-reference-invalid "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    is-alphanumerical "^2.0.0"
+    is-decimal "^2.0.0"
+    is-hexadecimal "^2.0.0"
+
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -5399,6 +6063,11 @@ property-information@^5.0.0:
   dependencies:
     xtend "^4.0.0"
 
+property-information@^7.0.0:
+  version "7.2.0"
+  resolved "https://npm.flatt.tech/property-information/-/property-information-7.2.0.tgz#0809b34264e995c0bfcd3227028a1e35210af80a"
+  integrity sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==
+
 proxy-addr@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -5573,6 +6242,23 @@ react-is@^19.0.0, react-is@^19.1.1, react-is@^19.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.0.tgz#ddc3b4a4e0f3336c3847f18b806506388d7b9973"
   integrity sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==
 
+react-markdown@^10.1.0:
+  version "10.1.0"
+  resolved "https://npm.flatt.tech/react-markdown/-/react-markdown-10.1.0.tgz#e22bc20faddbc07605c15284255653c0f3bad5ca"
+  integrity sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    hast-util-to-jsx-runtime "^2.0.0"
+    html-url-attributes "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
 react-remove-scroll-bar@^2.3.7:
   version "2.3.8"
   resolved "https://npm.flatt.tech/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
@@ -5729,12 +6415,54 @@ remark-gfm@^1.0.0:
     mdast-util-gfm "^0.1.0"
     micromark-extension-gfm "^0.3.0"
 
+remark-gfm@^4.0.1:
+  version "4.0.1"
+  resolved "https://npm.flatt.tech/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
+  integrity sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-gfm "^3.0.0"
+    micromark-extension-gfm "^3.0.0"
+    remark-parse "^11.0.0"
+    remark-stringify "^11.0.0"
+    unified "^11.0.0"
+
+remark-parse@^11.0.0:
+  version "11.0.0"
+  resolved "https://npm.flatt.tech/remark-parse/-/remark-parse-11.0.0.tgz#aa60743fcb37ebf6b069204eb4da304e40db45a1"
+  integrity sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unified "^11.0.0"
+
 remark-parse@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
   integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
     mdast-util-from-markdown "^0.8.0"
+
+remark-rehype@^11.0.0:
+  version "11.1.2"
+  resolved "https://npm.flatt.tech/remark-rehype/-/remark-rehype-11.1.2.tgz#2addaadda80ca9bd9aa0da763e74d16327683b37"
+  integrity sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    mdast-util-to-hast "^13.0.0"
+    unified "^11.0.0"
+    vfile "^6.0.0"
+
+remark-stringify@^11.0.0:
+  version "11.0.0"
+  resolved "https://npm.flatt.tech/remark-stringify/-/remark-stringify-11.0.0.tgz#4c5b01dd711c269df1aaae11743eb7e2e7636fd3"
+  integrity sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    unified "^11.0.0"
 
 repeat-string@^1.0.0:
   version "1.6.1"
@@ -6162,6 +6890,11 @@ space-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://npm.flatt.tech/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+
 spdx-correct@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
@@ -6265,6 +6998,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+stringify-entities@^4.0.0:
+  version "4.0.4"
+  resolved "https://npm.flatt.tech/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -6323,6 +7064,20 @@ structured-source@^4.0.0:
   integrity sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==
   dependencies:
     boundary "^2.0.0"
+
+style-to-js@^1.0.0:
+  version "1.1.21"
+  resolved "https://npm.flatt.tech/style-to-js/-/style-to-js-1.1.21.tgz#2908941187f857e79e28e9cd78008b9a0b3e0e8d"
+  integrity sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==
+  dependencies:
+    style-to-object "1.0.14"
+
+style-to-object@1.0.14:
+  version "1.0.14"
+  resolved "https://npm.flatt.tech/style-to-object/-/style-to-object-1.0.14.tgz#1d22f0e7266bb8c6d8cae5caf4ec4f005e08f611"
+  integrity sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==
+  dependencies:
+    inline-style-parser "0.2.7"
 
 stylis@4.2.0:
   version "4.2.0"
@@ -6986,6 +7741,11 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
@@ -6995,6 +7755,11 @@ trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
+trough@^2.0.0:
+  version "2.2.0"
+  resolved "https://npm.flatt.tech/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
+  integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
 tslib@^2.0.0, tslib@^2.1.0:
   version "2.8.1"
@@ -7051,6 +7816,19 @@ unicorn-magic@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
+
+unified@^11.0.0:
+  version "11.0.5"
+  resolved "https://npm.flatt.tech/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
+  integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    bail "^2.0.0"
+    devlop "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^6.0.0"
 
 unified@^8.4.0:
   version "8.4.2"
@@ -7121,12 +7899,33 @@ unist-util-is@^5.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
   integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
 
+unist-util-is@^6.0.0:
+  version "6.0.1"
+  resolved "https://npm.flatt.tech/unist-util-is/-/unist-util-is-6.0.1.tgz#d0a3f86f2dd0db7acd7d8c2478080b5c67f9c6a9"
+  integrity sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position@^5.0.0:
+  version "5.0.0"
+  resolved "https://npm.flatt.tech/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://npm.flatt.tech/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
 
 unist-util-visit-parents@^2.0.0:
   version "2.1.2"
@@ -7151,6 +7950,14 @@ unist-util-visit-parents@^4.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
+unist-util-visit-parents@^6.0.0:
+  version "6.0.2"
+  resolved "https://npm.flatt.tech/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz#777df7fb98652ce16b4b7cd999d0a1a40efa3a02"
+  integrity sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
 unist-util-visit@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
@@ -7166,6 +7973,15 @@ unist-util-visit@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^4.0.0"
+
+unist-util-visit@^5.0.0:
+  version "5.1.0"
+  resolved "https://npm.flatt.tech/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
+  integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -7294,6 +8110,14 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
+vfile-message@^4.0.0:
+  version "4.0.3"
+  resolved "https://npm.flatt.tech/vfile-message/-/vfile-message-4.0.3.tgz#87b44dddd7b70f0641c2e3ed0864ba73e2ea8df4"
+  integrity sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
 vfile@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
@@ -7303,6 +8127,14 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vfile@^6.0.0:
+  version "6.0.3"
+  resolved "https://npm.flatt.tech/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile-message "^4.0.0"
 
 watchpack@^2.4.4:
   version "2.5.1"
@@ -7517,3 +8349,8 @@ zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
   integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==
+
+zwitch@^2.0.0:
+  version "2.0.4"
+  resolved "https://npm.flatt.tech/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,6 +611,11 @@
   resolved "https://npm.flatt.tech/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
   integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
+"@heroicons/react@^2.2.0":
+  version "2.2.0"
+  resolved "https://npm.flatt.tech/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
+  integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
+
 "@hono/node-server@^1.19.9":
   version "1.19.13"
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.13.tgz#4838c766a1237253d4dde3281cf7d5c65186fd32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,28 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
   integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
 
+"@emnapi/core@^1.11.1":
+  version "1.11.3"
+  resolved "https://npm.flatt.tech/@emnapi/core/-/core-1.11.3.tgz#5e95348a42cd1e06f0b9aa380cd74091daa4d520"
+  integrity sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.3"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.11.1":
+  version "1.11.3"
+  resolved "https://npm.flatt.tech/@emnapi/runtime/-/runtime-1.11.3.tgz#84257ae3b0531eb2aec1ffa23d70700da007ba95"
+  integrity sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.3", "@emnapi/wasi-threads@^1.2.2":
+  version "1.2.3"
+  resolved "https://npm.flatt.tech/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz#c9bf72fd4be5b928aee894820e8d814ed73916e9"
+  integrity sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==
+  dependencies:
+    tslib "^2.4.0"
+
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"
@@ -647,6 +669,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz#7358043433b2e5da569aa02cbc4c121da3af27d7"
   integrity sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://npm.flatt.tech/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz#a58d31eaadaf92c6695680b2e1d464a9b8fbf7fc"
@@ -835,6 +862,13 @@
     prop-types "^15.8.1"
     react-is "^19.1.1"
 
+"@napi-rs/wasm-runtime@^1.1.4":
+  version "1.1.6"
+  resolved "https://npm.flatt.tech/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
+  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -873,6 +907,95 @@
   integrity sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==
   dependencies:
     semver "^7.3.5"
+
+"@parcel/watcher-android-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
+  integrity sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==
+
+"@parcel/watcher-darwin-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz#3d26dce38de6590ef79c47ec2c55793c06ad4f67"
+  integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+
+"@parcel/watcher-darwin-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz#99f3af3869069ccf774e4ddfccf7e64fd2311ef8"
+  integrity sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==
+
+"@parcel/watcher-freebsd-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz#14d6857741a9f51dfe51d5b08b7c8afdbc73ad9b"
+  integrity sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==
+
+"@parcel/watcher-linux-arm-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz#43c3246d6892381db473bb4f663229ad20b609a1"
+  integrity sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==
+
+"@parcel/watcher-linux-arm-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz#663750f7090bb6278d2210de643eb8a3f780d08e"
+  integrity sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz#ba60e1f56977f7e47cd7e31ad65d15fdcbd07e30"
+  integrity sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==
+
+"@parcel/watcher-linux-arm64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz#f7fbcdff2f04c526f96eac01f97419a6a99855d2"
+  integrity sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==
+
+"@parcel/watcher-linux-x64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz#4d2ea0f633eb1917d83d483392ce6181b6a92e4e"
+  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz#277b346b05db54f55657301dd77bdf99d63606ee"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+
+"@parcel/watcher-win32-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz#7e9e02a26784d47503de1d10e8eab6cceb524243"
+  integrity sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==
+
+"@parcel/watcher-win32-ia32@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz#2d0f94fa59a873cdc584bf7f6b1dc628ddf976e6"
+  integrity sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==
+
+"@parcel/watcher-win32-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz#ae52693259664ba6f2228fa61d7ee44b64ea0947"
+  integrity sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==
+
+"@parcel/watcher@2.5.1":
+  version "2.5.1"
+  resolved "https://npm.flatt.tech/@parcel/watcher/-/watcher-2.5.1.tgz#342507a9cfaaf172479a882309def1e991fb1200"
+  integrity sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==
+  dependencies:
+    detect-libc "^1.0.3"
+    is-glob "^4.0.3"
+    micromatch "^4.0.5"
+    node-addon-api "^7.0.0"
+  optionalDependencies:
+    "@parcel/watcher-android-arm64" "2.5.1"
+    "@parcel/watcher-darwin-arm64" "2.5.1"
+    "@parcel/watcher-darwin-x64" "2.5.1"
+    "@parcel/watcher-freebsd-x64" "2.5.1"
+    "@parcel/watcher-linux-arm-glibc" "2.5.1"
+    "@parcel/watcher-linux-arm-musl" "2.5.1"
+    "@parcel/watcher-linux-arm64-glibc" "2.5.1"
+    "@parcel/watcher-linux-arm64-musl" "2.5.1"
+    "@parcel/watcher-linux-x64-glibc" "2.5.1"
+    "@parcel/watcher-linux-x64-musl" "2.5.1"
+    "@parcel/watcher-win32-arm64" "2.5.1"
+    "@parcel/watcher-win32-ia32" "2.5.1"
+    "@parcel/watcher-win32-x64" "2.5.1"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1552,6 +1675,124 @@
   resolved "https://npm.flatt.tech/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
+"@tailwindcss/cli@^4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/cli/-/cli-4.3.3.tgz#763edd474c2f43ce82cdcedc80c0b3b23a86ba6f"
+  integrity sha512-ZvS/n1ZHOBKcVlhkt8l5NNr1EDXk1NboYO5CYDOs6NUmvT9z6bzkwsosaJftY57T/3gWNzWMJzIXLodZC8ssdw==
+  dependencies:
+    "@parcel/watcher" "2.5.1"
+    "@tailwindcss/node" "4.3.3"
+    "@tailwindcss/oxide" "4.3.3"
+    enhanced-resolve "^5.24.1"
+    mri "^1.2.0"
+    picocolors "^1.1.1"
+    tailwindcss "4.3.3"
+
+"@tailwindcss/node@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/node/-/node-4.3.3.tgz#38ff04309ff036ea3589a7bad9069c44ec9d3883"
+  integrity sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.5"
+    enhanced-resolve "^5.24.1"
+    jiti "^2.7.0"
+    lightningcss "1.32.0"
+    magic-string "^0.30.21"
+    source-map-js "^1.2.1"
+    tailwindcss "4.3.3"
+
+"@tailwindcss/oxide-android-arm64@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz#848f93034155daf7892185028dfb18143bfc7d07"
+  integrity sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==
+
+"@tailwindcss/oxide-darwin-arm64@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz#5c779e32c1c361beb75136fd8e2c627fcb9a5b28"
+  integrity sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==
+
+"@tailwindcss/oxide-darwin-x64@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz#ba292ff52fa3264139f7fe7874719ce0a4666875"
+  integrity sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==
+
+"@tailwindcss/oxide-freebsd-x64@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz#07e589487b9a636235a4ade48cefc1f9eeeec57f"
+  integrity sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz#0c8abc228d9e19e0065ddb707eba52e21855b3ff"
+  integrity sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==
+
+"@tailwindcss/oxide-linux-arm64-gnu@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz#5067dc7afd15d2b97adc77a91177dc4bec8d1b8b"
+  integrity sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==
+
+"@tailwindcss/oxide-linux-arm64-musl@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz#29ae5f279be2ce64db368711985b6ad8e4562e57"
+  integrity sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==
+
+"@tailwindcss/oxide-linux-x64-gnu@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz#7d693b40f69875744b499481359b227fd3ac3a3c"
+  integrity sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==
+
+"@tailwindcss/oxide-linux-x64-musl@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz#6a55d664f47c5ff9ad3f46bf05fe07d410b8cfd8"
+  integrity sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==
+
+"@tailwindcss/oxide-wasm32-wasi@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz#408a9bc620e68f1aaf0dfea33da7bd3b65f9e2ef"
+  integrity sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==
+  dependencies:
+    "@emnapi/core" "^1.11.1"
+    "@emnapi/runtime" "^1.11.1"
+    "@emnapi/wasi-threads" "^1.2.2"
+    "@napi-rs/wasm-runtime" "^1.1.4"
+    "@tybys/wasm-util" "^0.10.2"
+    tslib "^2.8.1"
+
+"@tailwindcss/oxide-win32-arm64-msvc@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz#3d582b00180fa4680e0b6c90be69fa5f4a209092"
+  integrity sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==
+
+"@tailwindcss/oxide-win32-x64-msvc@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz#ce4c663fef3b4fde67611a4c1391866f8c0aa79b"
+  integrity sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==
+
+"@tailwindcss/oxide@4.3.3":
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/@tailwindcss/oxide/-/oxide-4.3.3.tgz#6266109d025cfcb04f8e4c58954a6f630a415b7f"
+  integrity sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==
+  optionalDependencies:
+    "@tailwindcss/oxide-android-arm64" "4.3.3"
+    "@tailwindcss/oxide-darwin-arm64" "4.3.3"
+    "@tailwindcss/oxide-darwin-x64" "4.3.3"
+    "@tailwindcss/oxide-freebsd-x64" "4.3.3"
+    "@tailwindcss/oxide-linux-arm-gnueabihf" "4.3.3"
+    "@tailwindcss/oxide-linux-arm64-gnu" "4.3.3"
+    "@tailwindcss/oxide-linux-arm64-musl" "4.3.3"
+    "@tailwindcss/oxide-linux-x64-gnu" "4.3.3"
+    "@tailwindcss/oxide-linux-x64-musl" "4.3.3"
+    "@tailwindcss/oxide-wasm32-wasi" "4.3.3"
+    "@tailwindcss/oxide-win32-arm64-msvc" "4.3.3"
+    "@tailwindcss/oxide-win32-x64-msvc" "4.3.3"
+
+"@tailwindcss/typography@^0.5.20":
+  version "0.5.20"
+  resolved "https://npm.flatt.tech/@tailwindcss/typography/-/typography-0.5.20.tgz#9feb7fb1d5f2f7b5360c22e24651210db74c34df"
+  integrity sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==
+  dependencies:
+    postcss-selector-parser "6.0.10"
+
 "@textlint-ja/textlint-rule-no-dropping-i@hata6502/textlint-rule-no-dropping-i":
   version "1.0.1"
   resolved "https://codeload.github.com/hata6502/textlint-rule-no-dropping-i/tar.gz/531ddbd0de12995d0ba3273316a4ae043d6b9720"
@@ -1862,6 +2103,13 @@
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@textlint/utils/-/utils-1.2.5.tgz#1406e179d44d130d8e60322f3f873a721c93ba75"
   integrity sha512-2vgz4x3tKK+R9N0OlOovJClRCHubxZi86ki218cvRVpoU9pPrHwkwZud+rjItDl2xFBj7Gujww7c0W1wyytWVQ==
+
+"@tybys/wasm-util@^0.10.2", "@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://npm.flatt.tech/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/debug@^0.0.30":
   version "0.0.30"
@@ -3000,6 +3248,11 @@ css-vendor@^2.0.8:
     "@babel/runtime" "^7.8.3"
     is-in-browser "^1.0.2"
 
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
 csstype@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
@@ -3116,6 +3369,16 @@ dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://npm.flatt.tech/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://npm.flatt.tech/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://npm.flatt.tech/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-node-es@^1.1.0:
   version "1.1.0"
@@ -3235,6 +3498,14 @@ enhanced-resolve@^5.17.4:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.3.0"
+
+enhanced-resolve@^5.24.1:
+  version "5.24.3"
+  resolved "https://npm.flatt.tech/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz#406bbf1ec20971265a30254f08030fce6a8207fe"
+  integrity sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.3.3"
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -4412,6 +4683,11 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jiti@^2.7.0:
+  version "2.7.0"
+  resolved "https://npm.flatt.tech/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
+  integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
+
 jose@^6.1.3:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/jose/-/jose-6.1.3.tgz#8453d7be88af7bb7d64a0481d6a35a0145ba3ea5"
@@ -4596,6 +4872,80 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lightningcss-android-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
+  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
+
+lightningcss-darwin-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+
+lightningcss-darwin-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
+  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
+
+lightningcss-freebsd-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
+  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
+
+lightningcss-linux-arm-gnueabihf@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
+  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
+
+lightningcss-linux-arm64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
+  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
+
+lightningcss-linux-arm64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
+  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
+
+lightningcss-linux-x64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
+
+lightningcss-win32-arm64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
+  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
+
+lightningcss-win32-x64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
+  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+
+lightningcss@1.32.0:
+  version "1.32.0"
+  resolved "https://npm.flatt.tech/lightningcss/-/lightningcss-1.32.0.tgz#b85aae96486dcb1bf49a7c8571221273f4f1e4a9"
+  integrity sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.32.0"
+    lightningcss-darwin-arm64 "1.32.0"
+    lightningcss-darwin-x64 "1.32.0"
+    lightningcss-freebsd-x64 "1.32.0"
+    lightningcss-linux-arm-gnueabihf "1.32.0"
+    lightningcss-linux-arm64-gnu "1.32.0"
+    lightningcss-linux-arm64-musl "1.32.0"
+    lightningcss-linux-x64-gnu "1.32.0"
+    lightningcss-linux-x64-musl "1.32.0"
+    lightningcss-win32-arm64-msvc "1.32.0"
+    lightningcss-win32-x64-msvc "1.32.0"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -4683,6 +5033,13 @@ lru_map@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.4.1.tgz#f7b4046283c79fb7370c36f8fca6aee4324b0a98"
   integrity sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://npm.flatt.tech/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 make-fetch-happen@^14.0.3:
   version "14.0.3"
@@ -5373,7 +5730,7 @@ micromark@^4.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
-micromatch@^4.0.8:
+micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -5549,6 +5906,11 @@ morpheme-match@^2.0.4:
   resolved "https://registry.yarnpkg.com/morpheme-match/-/morpheme-match-2.0.4.tgz#4ce77a4d6b51c0b33b3ca6d398363c42756b0c99"
   integrity sha512-C3U5g2h47dpztGVePLA8w2O1aQEvuJORwIcahWaCG91YPrq+0u7qcPsF9Nqqe8noFvHwgO7b2EEk3iPnYuGTew==
 
+mri@^1.2.0:
+  version "1.2.0"
+  resolved "https://npm.flatt.tech/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -5627,6 +5989,11 @@ nlcst-types@^1.2.4:
   integrity sha512-8wlNDXWlAk/i+QCFRDGet3ICLrFaHNc4+bF51VywnZmRuW0oVT5qnskHNebEWe1JNpU0ECI1oLqMDYaj91fzSA==
   dependencies:
     unist-types "^1.1.5"
+
+node-addon-api@^7.0.0:
+  version "7.1.1"
+  resolved "https://npm.flatt.tech/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-gyp@^11.2.0:
   version "11.2.0"
@@ -6001,6 +6368,14 @@ possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://npm.flatt.tech/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -6867,6 +7242,11 @@ sorted-joyo-kanji@^0.2.0:
     joyo-kanji "^0.2.1"
     sorted-array "^2.0.1"
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://npm.flatt.tech/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -7140,10 +7520,20 @@ table@^6.9.0:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
+tailwindcss@4.3.3, tailwindcss@^4.3.3:
+  version "4.3.3"
+  resolved "https://npm.flatt.tech/tailwindcss/-/tailwindcss-4.3.3.tgz#c006861611c213c1877893ab5b23daa16be2bb55"
+  integrity sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==
+
 tapable@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.0.tgz#7e3ea6d5ca31ba8e078b560f0d83ce9a14aa8be6"
   integrity sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==
+
+tapable@^2.3.3:
+  version "2.3.3"
+  resolved "https://npm.flatt.tech/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
+  integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
 
 tar@^7.4.3:
   version "7.5.16"
@@ -7761,7 +8151,7 @@ trough@^2.0.0:
   resolved "https://npm.flatt.tech/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
   integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
-tslib@^2.0.0, tslib@^2.1.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://npm.flatt.tech/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -8065,7 +8455,7 @@ use-sync-external-store@^1.6.0:
   resolved "https://npm.flatt.tech/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
Agent builderが2026年11月に終了予定で、現在利用しているChatKitのOpenAI hosted backendから移行する必要があるため、自作AIチャットへ置き換えます。

## 変更内容

`@openai/chatkit-react`をassistant-uiとAI SDKへ置き換え、reCAPTCHAトークンとメッセージをCloud Run functionへ送信する構成に変更しました。

`get_memo`、`list_other_memos`、`get_other_memos`、`set_ai_lint_messages`は、assistant-uiのfrontend toolとして移行しました。

ThreadList UIは追加せず、メモごとのチャット履歴をLocal Storageへ保存・復元します。Suggestions、メッセージ編集、Markdown表示、自動スクロール、回答中表示にも対応しました。

既存のMUIのCardとCardContentは維持し、assistant-uiのPrimitiveをTailwind CSSとHeroiconsで表示しています。

ChatKitのscriptを削除し、CSPの接続先を新しいCloud Run functionへ変更しました。あわせて、メモ入力欄へplaceholderを追加し、見直し箇所を示すピンの位置を調整しました。
